### PR TITLE
Dockerfile updates (use current node lts/python versions, smaller distribution container)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,21 @@
 # ---- Stage 1: Build frontend ----
-FROM node:22-alpine AS frontend-build
+FROM node:24-alpine AS frontend-build
 WORKDIR /build
-COPY frontend/package.json frontend/package-lock.json* ./
-RUN npm install
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
 COPY frontend/ ./
 RUN npm run build
 
 # ---- Stage 2: Production image ----
-FROM python:3.12-slim
+FROM python:3.14-alpine
 WORKDIR /app
 
 COPY backend/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
+    uv pip install --system --compile-bytecode --no-cache-dir -r requirements.txt
+# bytecode compilation makes startup faster but the image bigger, see: https://docs.astral.sh/uv/pip/compatibility/#bytecode-compilation
 
 COPY backend/ .
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -855,6 +855,7 @@
       "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
         "debug": "^4.3.4",
@@ -895,6 +896,7 @@
       "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.17.tgz",
       "integrity": "sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/tern": "*"
       }
@@ -1022,6 +1024,7 @@
       "resolved": "https://registry.npmjs.org/bytemd/-/bytemd-1.22.0.tgz",
       "integrity": "sha512-2vmegXnnsOxNufRrrQGHYKwgTmx6H+h40ZZs3DAw/SS5O4mBzO9evc1HD39CqW9wglGNBJxMg257pv9pgAGl+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.11.7",
         "@types/codemirror": "^5.60.7",
@@ -1136,6 +1139,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2657,6 +2661,7 @@
       "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -2896,6 +2901,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
Thanks for the cool project! :)

I made some changes to the Dockerfile:
- use `node:24-alpine` instead of `node:22-alpine`
- use `python:3.14-alpine` instead of `python:3.12-slim`
- use uv from a temporarily build-time mounted container to install pip dependencies

This should give some better backend efficiency and makes the resulting container smaller.

If youre down I would also like to add a CI/CD pipeline via github actions so maintaining it will be easier.