### PR TITLE
feat: add github action workflows, arm64 support and dependabot.yml configuration, fix flask debug mode setting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Frontend (node/npm)
+  - package-ecosystem: "npm"
+    directory: "/frontend/"
+    schedule:
+      interval: "weekly"
+
+  # Backend (python)
+  - package-ecosystem: "pip"
+    # Ingests Cargo.toml
+    directory: "/backend/"
+    schedule:
+      interval: "weekly"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,0 +1,37 @@
+name: homelab-hub pr pipeline (dockerfile build smoke test)
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/homelab-hub
+
+jobs:
+  pr_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release_for_tag.yaml
+++ b/.github/workflows/release_for_tag.yaml
@@ -1,0 +1,70 @@
+name: homelab-hub release pipeline
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/homelab-hub
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.gh_release.outputs.id }}
+      release_upload_url: ${{ steps.gh_release.outputs.upload_url }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      # Create GitHub Release
+      - name: Create GitHub Release
+        id: gh_release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Release ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+  publish_docker:
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Push README.md to Dockerhub
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ env.IMAGE_NAME }}
+          short-description: 'Home Lab Hub - A self-hosted web application for managing and visualizing home lab infrastructure.'
+          enable-url-completion: true

--- a/.github/workflows/release_for_tag.yaml
+++ b/.github/workflows/release_for_tag.yaml
@@ -1,8 +1,11 @@
 name: homelab-hub release pipeline
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
 env:
   IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/homelab-hub
@@ -34,6 +37,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -48,6 +54,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 
@@ -55,10 +65,13 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Push README.md to Dockerhub
         uses: peter-evans/dockerhub-description@v5

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The application will automatically create the SQLite database at `data/homelab-h
 From the `backend/` directory:
 
 ```bash
+# to enable flask debug mode:
+export FLASK_DEBUG=true
 python wsgi.py
 ```
 
@@ -150,6 +152,8 @@ Access the application at `http://localhost:8000` (the built frontend files are 
 From the `backend/` directory, run Gunicorn:
 
 ```bash
+# to enable flask debug mode:
+export FLASK_DEBUG=true
 gunicorn -w 4 -b 127.0.0.1:5001 wsgi:app
 ```
 

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -3,4 +3,6 @@ from app import create_app
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5001)
+    enable_debug = os.getenv("FLASK_DEBUG", "false").lower() in ["true", "t", "yes", "y", "1"]
+    port = int(os.getenv("FLASK_PORT", 5001))
+    app.run(debug=enable_debug, port=port)


### PR DESCRIPTION
Here is some ported over work from my workflows of e.g. https://github.com/Gunzinger/imgc-rs adapted for this project:
- a dependabot configuration to get PRs from dependabot when updates are found (can be a bit naggy, can configure to your needs)
- a workflow to build a docker image and publish it to docker hub (and update the description there)
  - note that this does not do semantic versioning, shared tags or anything currently, see the output here: https://hub.docker.com/r/gunzinger/imgc-rs/tags
this publish pipeline can be triggered by simply pushing a tag with the right prefix ('v*.*.*' as configured in the workflow)
  - ⚠️ this requires you to setup up secrets for the workflow (`DOCKER_USERNAME` and `DOCKER_PASSWORD` i.e. token)
<img width="1128" height="956" alt="grafik" src="https://github.com/user-attachments/assets/82053f20-a884-49e5-8f6e-d96372f0d87c" />

- a workflow to build the dockerfile for PRs (could probably use some caching, be careful to restrict used images and settings there to your needs to avoid abuse)