### PR TITLE
Work around lack of support for 'IF NOT EXISTS' in sqlite 'ALTER TABLE'

### DIFF
--- a/backend/migrations/versions/001_initial_schema.py
+++ b/backend/migrations/versions/001_initial_schema.py
@@ -9,21 +9,13 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.exc import OperationalError
+
+from utils.migration_helpers import add_column_if_not_exists
 
 revision: str = "001"
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
-
-
-def add_column_if_not_exists(table_name, column):
-    """Add a column only if it doesn't already exist."""
-    try:
-        add_column_if_not_exists(table_name, column)
-    except OperationalError:
-        # Column already exists, skip
-        pass
 
 
 def upgrade() -> None:

--- a/backend/migrations/versions/002_add_icons_and_remove_app_url.py
+++ b/backend/migrations/versions/002_add_icons_and_remove_app_url.py
@@ -9,6 +9,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from utils.migration_helpers import add_column_if_not_exists
 
 revision: str = "002"
 down_revision: Union[str, None] = "001"
@@ -18,23 +19,23 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     # Add icon column to hardware
-    op.add_column("hardware", sa.Column("icon", sa.Text, nullable=True))
+    add_column_if_not_exists("hardware", sa.Column("icon", sa.Text, nullable=True))
     
     # Add icon column to vms
-    op.add_column("vms", sa.Column("icon", sa.Text, nullable=True))
+    add_column_if_not_exists("vms", sa.Column("icon", sa.Text, nullable=True))
     
     # Add icon column to apps and remove url column
-    op.add_column("apps", sa.Column("icon", sa.Text, nullable=True))
+    add_column_if_not_exists("apps", sa.Column("icon", sa.Text, nullable=True))
     op.drop_column("apps", "url")
     
     # Add icon column to storage
-    op.add_column("storage", sa.Column("icon", sa.Text, nullable=True))
+    add_column_if_not_exists("storage", sa.Column("icon", sa.Text, nullable=True))
     
     # Add color column to networks
-    op.add_column("networks", sa.Column("color", sa.Text, nullable=True))
+    add_column_if_not_exists("networks", sa.Column("color", sa.Text, nullable=True))
     
     # Add icon column to misc
-    op.add_column("misc", sa.Column("icon", sa.Text, nullable=True))
+    add_column_if_not_exists("misc", sa.Column("icon", sa.Text, nullable=True))
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/003_remove_hypervisor_add_misc_ip.py
+++ b/backend/migrations/versions/003_remove_hypervisor_add_misc_ip.py
@@ -9,6 +9,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from utils.migration_helpers import add_column_if_not_exists
 
 revision: str = "003"
 down_revision: Union[str, None] = "002"
@@ -21,7 +22,7 @@ def upgrade() -> None:
     op.drop_column("vms", "hypervisor")
     
     # Add ip_address column to misc
-    op.add_column("misc", sa.Column("ip_address", sa.Text, nullable=True))
+    add_column_if_not_exists("misc", sa.Column("ip_address", sa.Text, nullable=True))
 
 
 def downgrade() -> None:
@@ -29,4 +30,4 @@ def downgrade() -> None:
     op.drop_column("misc", "ip_address")
     
     # Add hypervisor back to vms
-    op.add_column("vms", sa.Column("hypervisor", sa.Text, nullable=True))
+    add_column_if_not_exists("vms", sa.Column("hypervisor", sa.Text, nullable=True))

--- a/backend/migrations/versions/004_add_hostname_to_misc.py
+++ b/backend/migrations/versions/004_add_hostname_to_misc.py
@@ -9,6 +9,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from utils.migration_helpers import add_column_if_not_exists
 
 revision: str = "004"
 down_revision: Union[str, None] = "003"
@@ -18,7 +19,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     # Add hostname column to misc
-    op.add_column("misc", sa.Column("hostname", sa.Text, nullable=True))
+    add_column_if_not_exists("misc", sa.Column("hostname", sa.Text, nullable=True))
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/005_storage_gb_to_tb.py
+++ b/backend/migrations/versions/005_storage_gb_to_tb.py
@@ -9,6 +9,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from utils.migration_helpers import add_column_if_not_exists
 
 revision: str = "005"
 down_revision: Union[str, None] = "004"
@@ -23,8 +24,8 @@ def upgrade() -> None:
     # 3. Drop old columns
     
     # Add new TB columns
-    op.add_column("storage", sa.Column("raw_space_tb", sa.Float, nullable=True))
-    op.add_column("storage", sa.Column("usable_space_tb", sa.Float, nullable=True))
+    add_column_if_not_exists("storage", sa.Column("raw_space_tb", sa.Float, nullable=True))
+    add_column_if_not_exists("storage", sa.Column("usable_space_tb", sa.Float, nullable=True))
     
     # Convert GB to TB (divide by 1024)
     op.execute("""
@@ -45,8 +46,8 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # Add back GB columns
-    op.add_column("storage", sa.Column("raw_space_gb", sa.Float, nullable=True))
-    op.add_column("storage", sa.Column("usable_space_gb", sa.Float, nullable=True))
+    add_column_if_not_exists("storage", sa.Column("raw_space_gb", sa.Float, nullable=True))
+    add_column_if_not_exists("storage", sa.Column("usable_space_gb", sa.Float, nullable=True))
     
     # Convert TB back to GB (multiply by 1024)
     op.execute("""

--- a/backend/migrations/versions/006_add_app_ip_address.py
+++ b/backend/migrations/versions/006_add_app_ip_address.py
@@ -7,6 +7,7 @@ Create Date: 2026-02-15
 """
 from alembic import op
 import sqlalchemy as sa
+from utils.migration_helpers import add_column_if_not_exists
 
 
 # revision identifiers, used by Alembic.
@@ -18,7 +19,7 @@ depends_on = None
 
 def upgrade():
     # Add ip_address column to apps table
-    op.add_column('apps', sa.Column('ip_address', sa.Text(), nullable=True))
+    add_column_if_not_exists('apps', sa.Column('ip_address', sa.Text(), nullable=True))
 
 
 def downgrade():

--- a/backend/migrations/versions/007_add_app_https.py
+++ b/backend/migrations/versions/007_add_app_https.py
@@ -7,6 +7,7 @@ Create Date: 2026-02-15
 """
 from alembic import op
 import sqlalchemy as sa
+from utils.migration_helpers import add_column_if_not_exists
 
 
 # revision identifiers, used by Alembic.
@@ -18,7 +19,7 @@ depends_on = None
 
 def upgrade():
     # Add https column to apps table
-    op.add_column('apps', sa.Column('https', sa.Boolean(), nullable=True, server_default='0'))
+    add_column_if_not_exists('apps', sa.Column('https', sa.Boolean(), nullable=True, server_default='0'))
 
 
 def downgrade():

--- a/backend/migrations/versions/008_add_mac_address.py
+++ b/backend/migrations/versions/008_add_mac_address.py
@@ -7,6 +7,7 @@ Create Date: 2026-02-18
 """
 from alembic import op
 import sqlalchemy as sa
+from utils.migration_helpers import add_column_if_not_exists
 
 
 # revision identifiers, used by Alembic.
@@ -18,10 +19,10 @@ depends_on = None
 
 def upgrade():
     # Add mac_address column to hardware table
-    op.add_column('hardware', sa.Column('mac_address', sa.Text(), nullable=True))
+    add_column_if_not_exists('hardware', sa.Column('mac_address', sa.Text(), nullable=True))
     
     # Add mac_address column to vms table
-    op.add_column('vms', sa.Column('mac_address', sa.Text(), nullable=True))
+    add_column_if_not_exists('vms', sa.Column('mac_address', sa.Text(), nullable=True))
 
 
 def downgrade():

--- a/backend/utils/migration_helpers.py
+++ b/backend/utils/migration_helpers.py
@@ -1,0 +1,11 @@
+from alembic import op
+from sqlalchemy.exc import OperationalError
+
+def add_column_if_not_exists(table_name, column):
+    """Add a column only if it doesn't already exist."""
+    try:
+        op.add_column(table_name,column)
+    except OperationalError:
+        # Column already exists, skip
+        pass
+


### PR DESCRIPTION
This PR fixes the problem with duplicate column errors in the migrations.
Sqlite3 doesn't support `IF NOT EXISTS` in the `ALTER TABLE` command so we use a helper function to ignore the `OperationalError` when it comes up.