### PR TITLE
feat: PostgreSQL support + Proxmox entities + Authentik/Caddy/N8N integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Database — PostgreSQL (recommended for production)
+DATABASE_URL=postgresql://homelab:homelab@db:5432/homelab_hub
+# Or use SQLite for local development:
+# DATABASE_URL=sqlite:///data/homelab-hub.db
+
+# PostgreSQL password (used by docker-compose)
+POSTGRES_PASSWORD=homelab
+
+# Authentik forward auth
+# Set to true to require authentication headers on all API requests
+REQUIRE_AUTH=false
+
+# Webhook secret for N8N / external export triggers
+# Required for POST /api/webhooks/export-trigger
+WEBHOOK_SECRET=
+
+# Flask environment
+FLASK_ENV=production

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to Homelab Hub
+
+## Local Development Setup
+
+### Prerequisites
+- Python 3.12+
+- Node.js 20+
+- (Optional) Docker & Docker Compose
+
+### Backend
+
+```bash
+cd backend
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+
+# Run with SQLite (default)
+flask --app app run --port 5001
+
+# Or with PostgreSQL
+export DATABASE_URL=postgresql://homelab:homelab@localhost:5432/homelab_hub
+flask --app app run --port 5001
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The dev server proxies API requests to `http://localhost:5001`.
+
+### Database Migrations
+
+```bash
+cd backend
+alembic upgrade head        # Apply all migrations
+alembic revision -m "desc"  # Create new migration
+```
+
+SQLite and PostgreSQL are both supported. Alembic uses batch mode automatically for SQLite.
+
+## Features
+
+### PostgreSQL Support
+Set `DATABASE_URL` to a PostgreSQL connection string. The app handles `postgres://` → `postgresql://` rewriting automatically. Docker Compose includes a `postgres:16-alpine` service.
+
+### Authentik Forward Auth
+Set `REQUIRE_AUTH=true` to enforce authentication. The app reads `X-Authentik-Username`, `X-Authentik-Name`, and `X-Authentik-Email` headers set by Authentik's forward auth outpost. See `docs/Caddyfile` for an example Caddy configuration.
+
+### Webhook Export
+Set `WEBHOOK_SECRET` and call:
+```bash
+curl -X POST -H "Authorization: Bearer <secret>" http://localhost:8000/api/webhooks/export-trigger
+```
+Exports are saved to `/data/exports/` and can be downloaded via `GET /api/webhooks/exports/<filename>`.
+
+### Proxmox Entities
+**Clusters** and **Nodes** are first-class entity types. VMs can belong to either a Hardware or a Node. VMs have a `vm_type` field (`vm` or `lxc`). Apps and Storage can also be parented to Nodes.
+
+## Docker
+
+```bash
+docker compose up -d
+```
+
+The compose file starts PostgreSQL and the app on an internal network. To expose the app directly (without Caddy), add a ports mapping:
+
+```yaml
+# docker-compose.override.yml
+services:
+  homelab-hub:
+    ports:
+      - "8000:8000"
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir -p /data
 # Make entrypoint script executable and ensure Unix line endings
 RUN sed -i 's/\r$//' /app/docker-entrypoint.sh && chmod +x /app/docker-entrypoint.sh
 
+# Default to SQLite if DATABASE_URL not provided (docker-compose sets PostgreSQL)
 ENV DATABASE_URL=sqlite:////data/homelab-hub.db
 ENV FLASK_ENV=production
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -21,6 +21,10 @@ def create_app(config_class=Config):
     except ImportError:
         pass
 
+    # Register auth middleware
+    from .auth import init_auth
+    init_auth(app)
+
     # Register blueprints
     from .routes import register_blueprints
     register_blueprints(app)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -39,8 +39,9 @@ def create_app(config_class=Config):
     @app.route("/<path:path>")
     def serve_spa(path):
         # Skip API routes - they're handled by blueprints
-        api_prefixes = ("api/", "inventory/", "hardware/", "vms/", "apps/", 
-                       "storage/", "shares/", "networks/", "misc/", "documents/", "map/")
+        api_prefixes = ("api/", "inventory/", "hardware/", "vms/", "apps/",
+                       "storage/", "shares/", "networks/", "misc/", "documents/", "map/",
+                       "nodes/", "clusters/")
         if path.startswith(api_prefixes):
             return jsonify(error="Not found"), 404
         file_path = os.path.join(static_dir, path)

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,28 @@
+from flask import g, jsonify, request
+
+
+def init_auth(app):
+    """Register Authentik forward-auth middleware."""
+    require_auth = app.config.get("REQUIRE_AUTH", False)
+
+    @app.before_request
+    def extract_auth_headers():
+        g.user = None
+        username = request.headers.get("X-Authentik-Username")
+        if username:
+            g.user = {
+                "username": username,
+                "name": request.headers.get("X-Authentik-Name", ""),
+                "email": request.headers.get("X-Authentik-Email", ""),
+            }
+        elif require_auth:
+            # Allow health check without auth
+            if request.path in ("/api/health",):
+                return
+            return jsonify(error="Authentication required"), 401
+
+    @app.route("/api/auth/user")
+    def auth_user():
+        if g.user:
+            return jsonify(g.user)
+        return jsonify({"username": None, "name": None, "email": None})

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,10 +3,18 @@ import os
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 
-class Config:
-    SQLALCHEMY_DATABASE_URI = os.environ.get(
+def _get_database_uri():
+    uri = os.environ.get(
         "DATABASE_URL", f"sqlite:///{os.path.join(basedir, '..', '..', 'data', 'homelab-hub.db')}"
     )
+    # Heroku-style postgres:// → postgresql:// rewrite for SQLAlchemy 2.x
+    if uri.startswith("postgres://"):
+        uri = uri.replace("postgres://", "postgresql://", 1)
+    return uri
+
+
+class Config:
+    SQLALCHEMY_DATABASE_URI = _get_database_uri()
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     # Allow larger request bodies for base64 image uploads (5MB)
     MAX_CONTENT_LENGTH = 5 * 1024 * 1024

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,3 +19,4 @@ class Config:
     # Allow larger request bodies for base64 image uploads (5MB)
     MAX_CONTENT_LENGTH = 5 * 1024 * 1024
     REQUIRE_AUTH = os.environ.get("REQUIRE_AUTH", "").lower() in ("true", "1", "yes")
+    WEBHOOK_SECRET = os.environ.get("WEBHOOK_SECRET", "")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -18,3 +18,4 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     # Allow larger request bodies for base64 image uploads (5MB)
     MAX_CONTENT_LENGTH = 5 * 1024 * 1024
+    REQUIRE_AUTH = os.environ.get("REQUIRE_AUTH", "").lower() in ("true", "1", "yes")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,8 @@
 from .base import db, BaseMixin
 from .document import Document
 from .hardware import Hardware
+from .cluster import Cluster
+from .node import Node
 from .vm import VM
 from .app_service import AppService
 from .storage import Storage
@@ -14,6 +16,8 @@ __all__ = [
     "BaseMixin",
     "Document",
     "Hardware",
+    "Cluster",
+    "Node",
     "VM",
     "AppService",
     "Storage",

--- a/backend/app/models/app_service.py
+++ b/backend/app/models/app_service.py
@@ -7,6 +7,7 @@ class AppService(BaseMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     hardware_id = db.Column(db.Integer, db.ForeignKey("hardware.id", ondelete="SET NULL"), nullable=True)
     vm_id = db.Column(db.Integer, db.ForeignKey("vms.id", ondelete="SET NULL"), nullable=True)
+    node_id = db.Column(db.Integer, db.ForeignKey("nodes.id", ondelete="SET NULL"), nullable=True)
     name = db.Column(db.Text, nullable=False)
     description = db.Column(db.Text)
     hostname = db.Column(db.Text)

--- a/backend/app/models/cluster.py
+++ b/backend/app/models/cluster.py
@@ -1,0 +1,13 @@
+from .base import db, BaseMixin
+
+
+class Cluster(BaseMixin, db.Model):
+    __tablename__ = "clusters"
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    name = db.Column(db.Text, nullable=False)
+    description = db.Column(db.Text)
+    icon = db.Column(db.Text)
+    notes = db.Column(db.Text)
+
+    nodes = db.relationship("Node", backref="cluster", lazy="select")

--- a/backend/app/models/node.py
+++ b/backend/app/models/node.py
@@ -1,0 +1,25 @@
+from .base import db, BaseMixin
+
+
+class Node(BaseMixin, db.Model):
+    __tablename__ = "nodes"
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    name = db.Column(db.Text, nullable=False)
+    hostname = db.Column(db.Text)
+    ip_address = db.Column(db.Text)
+    mac_address = db.Column(db.Text)
+    cpu = db.Column(db.Text)
+    cpu_cores = db.Column(db.Integer)
+    ram_gb = db.Column(db.Float)
+    os = db.Column(db.Text)
+    cluster_id = db.Column(db.Integer, db.ForeignKey("clusters.id", ondelete="SET NULL"), nullable=True)
+    icon = db.Column(db.Text)
+    notes = db.Column(db.Text)
+
+    vms = db.relationship("VM", backref="node", lazy="select",
+                          foreign_keys="VM.node_id")
+    apps = db.relationship("AppService", backref="node", lazy="select",
+                           foreign_keys="AppService.node_id")
+    storage_pools = db.relationship("Storage", backref="node", lazy="select",
+                                    foreign_keys="Storage.node_id")

--- a/backend/app/models/storage.py
+++ b/backend/app/models/storage.py
@@ -7,6 +7,7 @@ class Storage(BaseMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     hardware_id = db.Column(db.Integer, db.ForeignKey("hardware.id", ondelete="SET NULL"), nullable=True)
     vm_id = db.Column(db.Integer, db.ForeignKey("vms.id", ondelete="SET NULL"), nullable=True)
+    node_id = db.Column(db.Integer, db.ForeignKey("nodes.id", ondelete="SET NULL"), nullable=True)
     name = db.Column(db.Text, nullable=False)
     storage_type = db.Column(db.Text)
     raid_type = db.Column(db.Text)

--- a/backend/app/models/vm.py
+++ b/backend/app/models/vm.py
@@ -5,7 +5,8 @@ class VM(BaseMixin, db.Model):
     __tablename__ = "vms"
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    hardware_id = db.Column(db.Integer, db.ForeignKey("hardware.id", ondelete="CASCADE"), nullable=False)
+    hardware_id = db.Column(db.Integer, db.ForeignKey("hardware.id", ondelete="CASCADE"), nullable=True)
+    node_id = db.Column(db.Integer, db.ForeignKey("nodes.id", ondelete="CASCADE"), nullable=True)
     name = db.Column(db.Text, nullable=False)
     hostname = db.Column(db.Text)
     ip_address = db.Column(db.Text)
@@ -14,8 +15,11 @@ class VM(BaseMixin, db.Model):
     ram_gb = db.Column(db.Float)
     disk_gb = db.Column(db.Float)
     os = db.Column(db.Text)
+    vm_type = db.Column(db.Text, default="vm")  # "vm" or "lxc"
     icon = db.Column(db.Text)
     notes = db.Column(db.Text)
 
-    apps = db.relationship("AppService", backref="vm", lazy="select")
-    storage_pools = db.relationship("Storage", backref="vm", lazy="select")
+    apps = db.relationship("AppService", backref="vm", lazy="select",
+                           foreign_keys="AppService.vm_id")
+    storage_pools = db.relationship("Storage", backref="vm", lazy="select",
+                                    foreign_keys="Storage.vm_id")

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,5 +1,5 @@
-from . import apps, documents, hardware, inventory, map_routes, misc, networks, shares, storage, vms
 from flask import Blueprint
+
 
 def register_blueprints(app):
     from .documents import bp as documents_bp
@@ -12,6 +12,7 @@ def register_blueprints(app):
     from .misc import bp as misc_bp
     from .inventory import bp as inventory_bp
     from .map_routes import bp as map_bp
+    from .webhooks import bp as webhooks_bp
 
     app.register_blueprint(documents_bp)
     app.register_blueprint(hardware_bp)
@@ -23,3 +24,4 @@ def register_blueprints(app):
     app.register_blueprint(misc_bp)
     app.register_blueprint(inventory_bp)
     app.register_blueprint(map_bp)
+    app.register_blueprint(webhooks_bp)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -13,6 +13,8 @@ def register_blueprints(app):
     from .inventory import bp as inventory_bp
     from .map_routes import bp as map_bp
     from .webhooks import bp as webhooks_bp
+    from .nodes import bp as nodes_bp
+    from .clusters import bp as clusters_bp
 
     app.register_blueprint(documents_bp)
     app.register_blueprint(hardware_bp)
@@ -25,3 +27,5 @@ def register_blueprints(app):
     app.register_blueprint(inventory_bp)
     app.register_blueprint(map_bp)
     app.register_blueprint(webhooks_bp)
+    app.register_blueprint(nodes_bp)
+    app.register_blueprint(clusters_bp)

--- a/backend/app/routes/clusters.py
+++ b/backend/app/routes/clusters.py
@@ -1,0 +1,15 @@
+from flask import jsonify
+
+from ..models import db, Cluster
+from ._crud_factory import create_crud_blueprint
+
+bp = create_crud_blueprint("clusters", Cluster, detail_route=False)
+
+
+@bp.route("/<int:item_id>", methods=["GET"], endpoint="get_cluster_detail")
+def get_cluster_detail(item_id):
+    """Override GET detail to include related nodes."""
+    cluster = db.get_or_404(Cluster, item_id)
+    result = cluster.to_dict()
+    result["nodes"] = [node.to_dict() for node in cluster.nodes]
+    return jsonify(data=result)

--- a/backend/app/routes/inventory.py
+++ b/backend/app/routes/inventory.py
@@ -6,7 +6,9 @@ import json
 bp = Blueprint('inventory', __name__, url_prefix='/inventory')
 
 ENTITY_MAP = {
+    "clusters": Cluster,
     "hardware": Hardware,
+    "nodes": Node,
     "vms": VM,
     "apps": AppService,
     "storage": Storage,
@@ -49,7 +51,9 @@ def export_database():
     try:
         # Define the order of data to export to maintain relationships
         data = {
+            'clusters': [c.to_dict() for c in Cluster.query.all()],
             'hardware': [h.to_dict() for h in Hardware.query.all()],
+            'nodes': [n.to_dict() for n in Node.query.all()],
             'vms': [vm.to_dict() for vm in VM.query.all()],
             'apps': [app.to_dict() for app in AppService.query.all()],
             'storage': [s.to_dict() for s in Storage.query.all()],
@@ -71,9 +75,11 @@ def import_database():
         # Clear existing data in dependency order
         db.session.query(Share).delete()  # Delete shares before storage
         db.session.query(AppService).delete()
-        db.session.query(VM).delete()
-        db.session.query(Hardware).delete()
         db.session.query(Storage).delete()
+        db.session.query(VM).delete()
+        db.session.query(Node).delete()
+        db.session.query(Cluster).delete()
+        db.session.query(Hardware).delete()
         db.session.query(Network).delete()
         db.session.query(Misc).delete()
         db.session.query(Document).delete()
@@ -87,23 +93,37 @@ def import_database():
             item_copy.pop('updated_at', None)
             # Remove nested relationships (they'll be imported separately)
             item_copy.pop('shares', None)
+            item_copy.pop('nodes', None)
             return item_copy
 
-        # Import new data in dependency order
-        # First, import hardware (no dependencies)
+        # Import clusters (no dependencies)
+        if 'clusters' in import_data:
+            for item in import_data['clusters']:
+                cluster = Cluster(**clean_item(item))
+                db.session.add(cluster)
+
+        db.session.flush()
+
+        # Import hardware (no dependencies)
         if 'hardware' in import_data:
             for item in import_data['hardware']:
                 hardware = Hardware(**clean_item(item))
                 db.session.add(hardware)
-        
-        db.session.flush()  # Get IDs for hardware
 
-        # Import VMs (depends on hardware)
+        # Import nodes (depends on clusters)
+        if 'nodes' in import_data:
+            for item in import_data['nodes']:
+                node = Node(**clean_item(item))
+                db.session.add(node)
+
+        db.session.flush()  # Get IDs for hardware and nodes
+
+        # Import VMs (depends on hardware/nodes)
         if 'vms' in import_data:
             for item in import_data['vms']:
                 vm = VM(**clean_item(item))
                 db.session.add(vm)
-        
+
         db.session.flush()  # Get IDs for VMs
 
         # Import apps (depends on hardware and VMs)

--- a/backend/app/routes/map_routes.py
+++ b/backend/app/routes/map_routes.py
@@ -3,13 +3,15 @@ from ipaddress import ip_address, ip_network, AddressValueError
 
 from ..models import (
     db, Hardware, VM, AppService, Storage, Network, Misc, Share,
-    NetworkMember, Relationship, MapLayout, MapEdge,
+    NetworkMember, Relationship, MapLayout, MapEdge, Node, Cluster,
 )
 
 bp = Blueprint("map", __name__, url_prefix="/api/map")
 
 ENTITY_MAP = {
+    "clusters": Cluster,
     "hardware": Hardware,
+    "nodes": Node,
     "vms": VM,
     "apps": AppService,
     "storage": Storage,
@@ -55,7 +57,9 @@ def get_graph():
         for item in model.query.all():
             # Assign ranks for hierarchical layout
             rank_map = {
+                "clusters": -1,
                 "hardware": 0,
+                "nodes": 0,
                 "vms": 1,
                 "apps": 2,
                 "storage": 2,
@@ -81,6 +85,10 @@ def get_graph():
                     node_data["icon"] = item.icon
                     node_data["label"] = item.icon  # Only show the icon
             
+            # Add vm_type for VMs (vm or lxc)
+            if hasattr(item, "vm_type") and item.vm_type:
+                node_data["vmType"] = item.vm_type
+
             # Automatically determine network membership based on IP address
             if hasattr(item, "ip_address") and item.ip_address:
                 network = get_network_for_ip(item.ip_address)
@@ -93,17 +101,45 @@ def get_graph():
             nodes.append({"data": node_data})
 
     # Edges from FK relationships
+    # Cluster → Node
+    for node in Node.query.all():
+        if node.cluster_id:
+            edges.append({
+                "data": {
+                    "source": f"clusters-{node.cluster_id}",
+                    "target": f"nodes-{node.id}",
+                    "label": "hosts",
+                }
+            })
+
     for vm in VM.query.all():
-        edges.append({
-            "data": {
-                "source": f"hardware-{vm.hardware_id}",
-                "target": f"vms-{vm.id}",
-                "label": "hosts",
-            }
-        })
+        if vm.node_id:
+            edges.append({
+                "data": {
+                    "source": f"nodes-{vm.node_id}",
+                    "target": f"vms-{vm.id}",
+                    "label": "hosts",
+                }
+            })
+        elif vm.hardware_id:
+            edges.append({
+                "data": {
+                    "source": f"hardware-{vm.hardware_id}",
+                    "target": f"vms-{vm.id}",
+                    "label": "hosts",
+                }
+            })
 
     for app in AppService.query.all():
-        if app.hardware_id:
+        if app.node_id:
+            edges.append({
+                "data": {
+                    "source": f"nodes-{app.node_id}",
+                    "target": f"apps-{app.id}",
+                    "label": "runs",
+                }
+            })
+        elif app.hardware_id:
             edges.append({
                 "data": {
                     "source": f"hardware-{app.hardware_id}",
@@ -121,7 +157,15 @@ def get_graph():
             })
 
     for s in Storage.query.all():
-        if s.hardware_id:
+        if s.node_id:
+            edges.append({
+                "data": {
+                    "source": f"nodes-{s.node_id}",
+                    "target": f"storage-{s.id}",
+                    "label": "storage",
+                }
+            })
+        elif s.hardware_id:
             edges.append({
                 "data": {
                     "source": f"hardware-{s.hardware_id}",

--- a/backend/app/routes/nodes.py
+++ b/backend/app/routes/nodes.py
@@ -1,0 +1,19 @@
+from flask import jsonify
+
+from ..models import db, Node
+from ._crud_factory import create_crud_blueprint
+
+bp = create_crud_blueprint("nodes", Node, detail_route=False)
+
+
+@bp.route("/<int:item_id>", methods=["GET"], endpoint="get_node_detail")
+def get_node_detail(item_id):
+    """Override GET detail to include related VMs, apps, and storage."""
+    node = db.get_or_404(Node, item_id)
+    result = node.to_dict()
+    result["vms"] = [vm.to_dict() for vm in node.vms]
+    result["apps"] = [app.to_dict() for app in node.apps]
+    result["storage_pools"] = [s.to_dict() for s in node.storage_pools]
+    if node.cluster:
+        result["cluster_name"] = node.cluster.name
+    return jsonify(data=result)

--- a/backend/app/routes/webhooks.py
+++ b/backend/app/routes/webhooks.py
@@ -1,0 +1,75 @@
+import json
+import os
+from datetime import datetime, timezone
+
+from flask import Blueprint, current_app, jsonify, request, send_from_directory
+
+from ..models import *
+from ..models.base import db
+
+bp = Blueprint("webhooks", __name__, url_prefix="/api/webhooks")
+
+EXPORTS_DIR = "/data/exports"
+
+
+def _check_webhook_auth():
+    """Validate webhook secret from Authorization header or X-Webhook-Secret."""
+    secret = current_app.config.get("WEBHOOK_SECRET", "")
+    if not secret:
+        return jsonify(error="WEBHOOK_SECRET not configured"), 500
+
+    auth = request.headers.get("Authorization", "")
+    header_secret = request.headers.get("X-Webhook-Secret", "")
+
+    if auth.startswith("Bearer "):
+        token = auth[7:]
+        if token == secret:
+            return None
+    if header_secret == secret:
+        return None
+
+    return jsonify(error="Unauthorized"), 401
+
+
+@bp.route("/export-trigger", methods=["POST"])
+def export_trigger():
+    """Trigger a database export (for use by N8N or other webhook callers)."""
+    auth_error = _check_webhook_auth()
+    if auth_error:
+        return auth_error
+
+    try:
+        data = {
+            "hardware": [h.to_dict() for h in Hardware.query.all()],
+            "vms": [vm.to_dict() for vm in VM.query.all()],
+            "apps": [app.to_dict() for app in AppService.query.all()],
+            "storage": [s.to_dict() for s in Storage.query.all()],
+            "networks": [n.to_dict() for n in Network.query.all()],
+            "misc": [m.to_dict() for m in Misc.query.all()],
+            "documents": [d.to_dict() for d in Document.query.all()],
+        }
+
+        os.makedirs(EXPORTS_DIR, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        filename = f"export_{timestamp}.json"
+        filepath = os.path.join(EXPORTS_DIR, filename)
+
+        with open(filepath, "w") as f:
+            json.dump(data, f, indent=2, default=str)
+
+        return jsonify(
+            status="ok",
+            filename=filename,
+            download_url=f"/api/webhooks/exports/{filename}",
+        )
+    except Exception as e:
+        return jsonify(error=str(e)), 500
+
+
+@bp.route("/exports/<filename>", methods=["GET"])
+def download_export(filename):
+    """Download a previously generated export file."""
+    # Prevent path traversal
+    if "/" in filename or "\\" in filename or ".." in filename:
+        return jsonify(error="Invalid filename"), 400
+    return send_from_directory(EXPORTS_DIR, filename, as_attachment=True)

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,29 +1,11 @@
 #!/bin/sh
 set -e
-
-# Wait for PostgreSQL if DATABASE_URL points to one
-if echo "$DATABASE_URL" | grep -q "postgresql"; then
-  echo "Waiting for PostgreSQL..."
-  # Extract host:port from DATABASE_URL
-  PG_HOST=$(echo "$DATABASE_URL" | sed -n 's|.*@\([^:/]*\).*|\1|p')
-  PG_PORT=$(echo "$DATABASE_URL" | sed -n 's|.*@[^:]*:\([0-9]*\).*|\1|p')
-  PG_PORT=${PG_PORT:-5432}
-
-  for i in $(seq 1 30); do
-    if nc -z "$PG_HOST" "$PG_PORT" 2>/dev/null; then
-      echo "PostgreSQL is ready."
-      break
-    fi
-    echo "Waiting for PostgreSQL ($i/30)..."
-    sleep 1
-  done
-fi
-
-# Create exports directory
-mkdir -p /data/exports
-
-echo "Running database migrations..."
-alembic upgrade head
-
-echo "Starting application..."
-exec gunicorn --bind 0.0.0.0:8000 --workers 1 --timeout 120 wsgi:app
+echo "Waiting for PostgreSQL..."
+until python -c "import psycopg2,os,sys; psycopg2.connect(os.environ['DATABASE_URL']); sys.exit(0)" 2>/dev/null; do
+  sleep 1
+done
+echo "PostgreSQL ready."
+cd /app
+python -c "from app import create_app, db; app=create_app(); app.app_context().push(); db.create_all()"
+alembic stamp head 2>/dev/null || true
+exec gunicorn --bind 0.0.0.0:8000 --workers 2 wsgi:app

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,6 +1,24 @@
 #!/bin/sh
 set -e
 
+# Wait for PostgreSQL if DATABASE_URL points to one
+if echo "$DATABASE_URL" | grep -q "postgresql"; then
+  echo "Waiting for PostgreSQL..."
+  # Extract host:port from DATABASE_URL
+  PG_HOST=$(echo "$DATABASE_URL" | sed -n 's|.*@\([^:/]*\).*|\1|p')
+  PG_PORT=$(echo "$DATABASE_URL" | sed -n 's|.*@[^:]*:\([0-9]*\).*|\1|p')
+  PG_PORT=${PG_PORT:-5432}
+
+  for i in $(seq 1 30); do
+    if nc -z "$PG_HOST" "$PG_PORT" 2>/dev/null; then
+      echo "PostgreSQL is ready."
+      break
+    fi
+    echo "Waiting for PostgreSQL ($i/30)..."
+    sleep 1
+  done
+fi
+
 echo "Running database migrations..."
 alembic upgrade head
 

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -19,6 +19,9 @@ if echo "$DATABASE_URL" | grep -q "postgresql"; then
   done
 fi
 
+# Create exports directory
+mkdir -p /data/exports
+
 echo "Running database migrations..."
 alembic upgrade head
 

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -23,6 +23,12 @@ config.set_main_option("sqlalchemy.url", flask_app.config["SQLALCHEMY_DATABASE_U
 target_metadata = db.metadata
 
 
+def _use_batch():
+    """Use batch mode for SQLite (required for ALTER TABLE operations)."""
+    url = config.get_main_option("sqlalchemy.url") or ""
+    return url.startswith("sqlite")
+
+
 def run_migrations_offline():
     """Run migrations in 'offline' mode."""
     url = config.get_main_option("sqlalchemy.url")
@@ -31,6 +37,7 @@ def run_migrations_offline():
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        render_as_batch=_use_batch(),
     )
 
     with context.begin_transaction():
@@ -46,7 +53,11 @@ def run_migrations_online():
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            render_as_batch=_use_batch(),
+        )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/backend/migrations/versions/009_add_proxmox_entities.py
+++ b/backend/migrations/versions/009_add_proxmox_entities.py
@@ -1,0 +1,72 @@
+"""Add Proxmox node and cluster entities
+
+Revision ID: 009_add_proxmox_entities
+Revises: 008_add_mac_address
+Create Date: 2026-03-04
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from utils.migration_helpers import add_column_if_not_exists
+
+
+# revision identifiers, used by Alembic.
+revision = '009_add_proxmox_entities'
+down_revision = '008_add_mac_address'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create clusters table
+    op.create_table(
+        'clusters',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('name', sa.Text(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('icon', sa.Text(), nullable=True),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    # Create nodes table
+    op.create_table(
+        'nodes',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('name', sa.Text(), nullable=False),
+        sa.Column('hostname', sa.Text(), nullable=True),
+        sa.Column('ip_address', sa.Text(), nullable=True),
+        sa.Column('mac_address', sa.Text(), nullable=True),
+        sa.Column('cpu', sa.Text(), nullable=True),
+        sa.Column('cpu_cores', sa.Integer(), nullable=True),
+        sa.Column('ram_gb', sa.Float(), nullable=True),
+        sa.Column('os', sa.Text(), nullable=True),
+        sa.Column('cluster_id', sa.Integer(), nullable=True),
+        sa.Column('icon', sa.Text(), nullable=True),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['cluster_id'], ['clusters.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    # Add node_id to vms (and make hardware_id nullable)
+    add_column_if_not_exists('vms', sa.Column('node_id', sa.Integer(), nullable=True))
+    add_column_if_not_exists('vms', sa.Column('vm_type', sa.Text(), nullable=True))
+
+    # Add node_id to apps
+    add_column_if_not_exists('apps', sa.Column('node_id', sa.Integer(), nullable=True))
+
+    # Add node_id to storage
+    add_column_if_not_exists('storage', sa.Column('node_id', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('storage', 'node_id')
+    op.drop_column('apps', 'node_id')
+    op.drop_column('vms', 'vm_type')
+    op.drop_column('vms', 'node_id')
+    op.drop_table('nodes')
+    op.drop_table('clusters')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ flask-sqlalchemy==3.1.1
 sqlalchemy==2.0.36
 alembic==1.14.1
 gunicorn==23.0.0
+psycopg2-binary==2.9.10

--- a/backend/utils/migration_helpers.py
+++ b/backend/utils/migration_helpers.py
@@ -1,11 +1,19 @@
 from alembic import op
-from sqlalchemy.exc import OperationalError
+import sqlalchemy as sa
+from sqlalchemy import inspect, text
+
 
 def add_column_if_not_exists(table_name, column):
-    """Add a column only if it doesn't already exist."""
-    try:
-        op.add_column(table_name,column)
-    except OperationalError:
-        # Column already exists, skip
-        pass
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    columns = [c['name'] for c in inspector.get_columns(table_name)]
+    if column.name not in columns:
+        op.add_column(table_name, column)
 
+
+def drop_column_if_exists(table_name, column_name):
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    columns = [c['name'] for c in inspector.get_columns(table_name)]
+    if column_name in columns:
+        op.drop_column(table_name, column_name)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,27 @@
 services:
+  db:
+    image: postgres:16-alpine
+    container_name: homelab-hub-db
+    environment:
+      POSTGRES_DB: homelab_hub
+      POSTGRES_USER: homelab
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-homelab}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
+
   homelab-hub:
     image: raidowl/homelab-hub:latest
     container_name: homelab-hub
+    environment:
+      DATABASE_URL: postgresql://homelab:${POSTGRES_PASSWORD:-homelab}@db:5432/homelab_hub
     ports:
       - "8000:8000"
     volumes:
       - ./data:/data
+    depends_on:
+      - db
     restart: unless-stopped
+
+volumes:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-homelab}
     volumes:
       - pgdata:/var/lib/postgresql/data
+    networks:
+      - internal
     restart: unless-stopped
 
   homelab-hub:
@@ -15,13 +17,18 @@ services:
     container_name: homelab-hub
     environment:
       DATABASE_URL: postgresql://homelab:${POSTGRES_PASSWORD:-homelab}@db:5432/homelab_hub
-    ports:
-      - "8000:8000"
     volumes:
       - ./data:/data
+    networks:
+      - internal
+    expose:
+      - "8000"
     depends_on:
       - db
     restart: unless-stopped
 
 volumes:
   pgdata:
+
+networks:
+  internal:

--- a/docs/Caddyfile
+++ b/docs/Caddyfile
@@ -1,0 +1,19 @@
+# Example Caddyfile for Homelab Hub behind Authentik forward auth
+#
+# Prerequisites:
+# - Authentik outpost running (e.g., at authentik.example.com)
+# - homelab-hub container on the same Docker network
+#
+# Adjust domains and outpost URL to match your setup.
+
+homelab.example.com {
+	# Forward auth to Authentik outpost
+	forward_auth authentik-outpost:9000 {
+		uri /outpost.goauthentik.io/auth/caddy
+		copy_headers X-Authentik-Username X-Authentik-Name X-Authentik-Email X-Authentik-Groups
+		trusted_proxies private_ranges
+	}
+
+	# Reverse proxy to homelab-hub
+	reverse_proxy homelab-hub:8000
+}

--- a/frontend/src/components/Layout.svelte
+++ b/frontend/src/components/Layout.svelte
@@ -1,8 +1,23 @@
 <script>
+  import { onMount } from "svelte";
   import Sidebar from "./Sidebar.svelte";
 
   // In production (Docker), use relative URLs. In dev, use explicit URL for proxy.
   const API_BASE = import.meta.env.PROD ? '' : (import.meta.env.VITE_API_URL || 'http://localhost:5001');
+
+  let authUser = null;
+
+  onMount(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/user`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.username) authUser = data;
+      }
+    } catch (e) {
+      // Auth not available — ignore
+    }
+  });
 
   async function exportDatabase() {
     try {
@@ -72,6 +87,9 @@
   <header class="header">
     <h1>Home Lab Hub</h1>
     <div class="header-actions">
+      {#if authUser}
+        <span class="auth-user">{authUser.name || authUser.username}</span>
+      {/if}
       <button class="btn btn-primary" on:click={exportDatabase}>Export Data</button>
       <button class="btn btn-secondary" on:click={triggerImport}>Import Data</button>
       <input id="import-file-input" type="file" accept=".json" style="display: none;" on:change={importDatabase} />
@@ -110,6 +128,13 @@
   .header-actions {
     display: flex;
     gap: 0.5rem;
+    align-items: center;
+  }
+
+  .auth-user {
+    color: #aaa;
+    font-size: 0.9rem;
+    margin-right: 0.5rem;
   }
   
   .btn {

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -2,6 +2,8 @@
   import { location } from "svelte-spa-router";
 
   const inventoryTypes = [
+    { key: "clusters", label: "Clusters" },
+    { key: "nodes", label: "Nodes" },
     { key: "hardware", label: "Hardware" },
     { key: "vms", label: "VMs" },
     { key: "apps", label: "Apps" },

--- a/frontend/src/components/inventory/ClusterForm.svelte
+++ b/frontend/src/components/inventory/ClusterForm.svelte
@@ -1,0 +1,12 @@
+<script>
+  import IconPicker from "./IconPicker.svelte";
+
+  export let item = {};
+</script>
+
+<div class="grid">
+  <label>Name *<input type="text" bind:value={item.name} required /></label>
+  <label>Description<input type="text" bind:value={item.description} /></label>
+</div>
+<IconPicker bind:value={item.icon} />
+<label>Notes<textarea bind:value={item.notes} rows="3"></textarea></label>

--- a/frontend/src/components/inventory/EntityList.svelte
+++ b/frontend/src/components/inventory/EntityList.svelte
@@ -3,6 +3,8 @@
   import { get, post, del } from "../../lib/api.js";
   import { addToast } from "../../lib/stores.js";
   import Modal from "../Modal.svelte";
+  import ClusterForm from "./ClusterForm.svelte";
+  import NodeForm from "./NodeForm.svelte";
   import HardwareForm from "./HardwareForm.svelte";
   import VmForm from "./VmForm.svelte";
   import AppForm from "./AppForm.svelte";
@@ -21,6 +23,8 @@
   let sortDirection = 'asc';
 
   const FORMS = {
+    clusters: ClusterForm,
+    nodes: NodeForm,
     hardware: HardwareForm,
     vms: VmForm,
     apps: AppForm,
@@ -30,8 +34,10 @@
   };
 
   const COLUMNS = {
+    clusters: ["name", "description"],
+    nodes: ["name", "hostname", "ip_address", "os", "cpu", "ram_gb"],
     hardware: ["name", "hostname", "ip_address", "os", "cpu", "ram_gb"],
-    vms: ["name", "hostname", "ip_address", "os", "cpu_cores", "ram_gb"],
+    vms: ["name", "hostname", "ip_address", "os", "vm_type", "cpu_cores", "ram_gb"],
     apps: ["name", "hostname", "ip_address", "external_hostname", "port"],
     storage: ["name", "storage_type", "raid_type", "raw_space_tb", "usable_space_tb"],
     networks: ["name", "vlan_id", "subnet", "gateway"],
@@ -48,6 +54,7 @@
     usable_space_tb: "Usable (TB)",
     storage_type: "Type",
     raid_type: "RAID",
+    vm_type: "VM Type",
   };
 
   function label(col) {

--- a/frontend/src/components/inventory/NodeForm.svelte
+++ b/frontend/src/components/inventory/NodeForm.svelte
@@ -5,52 +5,26 @@
 
   export let item = {};
 
-  let hardwareOptions = [];
-  let nodeOptions = [];
+  let clusterOptions = [];
 
   onMount(async () => {
     try {
-      const [hwRes, nodeRes] = await Promise.all([
-        get("/hardware"),
-        get("/nodes"),
-      ]);
-      hardwareOptions = hwRes.data;
-      nodeOptions = nodeRes.data;
+      const res = await get("/clusters");
+      clusterOptions = res.data;
     } catch (e) {
-      // ignore — dropdowns will be empty
+      // ignore
     }
   });
-
-  // Default vm_type
-  $: if (!item.vm_type) item.vm_type = "vm";
 </script>
 
 <div class="grid">
   <label>Name *<input type="text" bind:value={item.name} required /></label>
   <label>
-    Type
-    <select bind:value={item.vm_type}>
-      <option value="vm">VM</option>
-      <option value="lxc">LXC Container</option>
-    </select>
-  </label>
-</div>
-<div class="grid">
-  <label>
-    Hardware
-    <select bind:value={item.hardware_id}>
-      <option value="">None</option>
-      {#each hardwareOptions as hw}
-        <option value={hw.id}>{hw.name}</option>
-      {/each}
-    </select>
-  </label>
-  <label>
-    Node
-    <select bind:value={item.node_id}>
-      <option value="">None</option>
-      {#each nodeOptions as node}
-        <option value={node.id}>{node.name}</option>
+    Cluster
+    <select bind:value={item.cluster_id}>
+      <option value="">No cluster</option>
+      {#each clusterOptions as cluster}
+        <option value={cluster.id}>{cluster.name}</option>
       {/each}
     </select>
   </label>
@@ -64,9 +38,9 @@
   <label>OS<input type="text" bind:value={item.os} /></label>
 </div>
 <div class="grid">
+  <label>CPU<input type="text" bind:value={item.cpu} /></label>
   <label>CPU Cores<input type="number" bind:value={item.cpu_cores} /></label>
   <label>RAM (GB)<input type="number" step="0.1" bind:value={item.ram_gb} /></label>
-  <label>Disk (GB)<input type="number" step="0.1" bind:value={item.disk_gb} /></label>
 </div>
 <IconPicker bind:value={item.icon} />
 <label>Notes<textarea bind:value={item.notes} rows="3"></textarea></label>

--- a/frontend/src/components/map/NetworkMap.svelte
+++ b/frontend/src/components/map/NetworkMap.svelte
@@ -17,6 +17,8 @@
   let tooltip = { visible: false, text: "", x: 0, y: 0 };
   
   // Visibility toggles for each node type
+  let showClusters = true;
+  let showNodes = true;
   let showHardware = true;
   let showVms = true;
   let showApps = true;
@@ -45,6 +47,8 @@
   }
 
   const NODE_STYLES = {
+    clusters:  { shape: "round-pentagon",   color: "#FFCDD2" },  // Pastel red
+    nodes:     { shape: "hexagon",          color: "#B3E5FC" },  // Pastel light blue
     hardware:  { shape: "hexagon",          color: "#C5E1F5" },  // Pastel blue
     vms:       { shape: "ellipse",          color: "#C8E6C9" },  // Pastel green
     apps:      { shape: "round-rectangle", color: "#FFE0B2" },  // Pastel orange
@@ -132,6 +136,14 @@
               "background-color": s.color,
             },
           })),
+          // LXC containers get dashed border
+          {
+            selector: 'node[vmType="lxc"]',
+            style: {
+              "border-style": "dashed",
+              "border-width": 3,
+            },
+          },
           // Override color for nodes with network color
           {
             selector: "node[networkColor]",
@@ -222,6 +234,8 @@
   // Reactive statement to hide/show nodes by type
   $: if (cy) {
     const nodeTypes = [
+      { type: 'clusters', show: showClusters },
+      { type: 'nodes', show: showNodes },
       { type: 'hardware', show: showHardware },
       { type: 'vms', show: showVms },
       { type: 'apps', show: showApps },
@@ -553,6 +567,14 @@
   <h3>Show Inventory</h3>
   <div class="toggle-list">
     <label class="toggle-option">
+      <input type="checkbox" bind:checked={showClusters} />
+      <span>Clusters</span>
+    </label>
+    <label class="toggle-option">
+      <input type="checkbox" bind:checked={showNodes} />
+      <span>Nodes</span>
+    </label>
+    <label class="toggle-option">
       <input type="checkbox" bind:checked={showHardware} />
       <span>Hardware</span>
     </label>
@@ -580,6 +602,18 @@
 </div>
 
 <div class="legend">
+  <div class="legend-item">
+    <svg width="24" height="24" viewBox="0 0 16 16">
+      <polygon points="8,1 14,4 15,11 8,15 1,11 2,4" fill="#FFCDD2" stroke="#999" stroke-width="1"/>
+    </svg>
+    <span>clusters</span>
+  </div>
+  <div class="legend-item">
+    <svg width="24" height="24" viewBox="0 0 16 16">
+      <polygon points="8,1 15,5 15,11 8,15 1,11 1,5" fill="#B3E5FC" stroke="#999" stroke-width="1"/>
+    </svg>
+    <span>nodes</span>
+  </div>
   <div class="legend-item">
     <svg width="24" height="24" viewBox="0 0 16 16">
       <polygon points="8,1 15,5 15,11 8,15 1,11 1,5" fill="#C5E1F5" stroke="#999" stroke-width="1"/>


### PR DESCRIPTION
## What this PR adds

This fork extends Homelab Hub with several production-focused improvements. 
Splitting them up per topic below — happy to break into separate PRs if preferred.

### 🐘 PostgreSQL support (community-relevant)
- `psycopg2-binary` added to requirements
- Auto-rewrites `postgres://` → `postgresql://` for SQLAlchemy 2.x compatibility
- Alembic `render_as_batch=True` for SQLite dialect (dev stays on SQLite)
- `docker-compose.yml` includes `postgres:16-alpine` service with named volume
- `docker-entrypoint.sh` waits for PostgreSQL before running migrations

### 🖥️ Proxmox entity types (community-relevant)
- New models: `Cluster` and `Node` (Proxmox host) with full CRUD
- `VM` gets a `vm_type` field (`vm` / `lxc`) and optional `node_id` FK
- `AppService` and `Storage` can also be parented to a Node
- Network map: cluster → node → VM/LXC hierarchy with LXC shown as dashed border
- Migration `009_add_proxmox_entities.py` included

### 🔐 Authentik forward auth (self-hosted SSO)
- `backend/app/auth.py`: `before_request` middleware reads `X-Authentik-*` headers
- `GET /api/auth/user` returns current user info
- `REQUIRE_AUTH=true` env var enforces auth (skips `/api/health`)
- Username shown in Svelte layout header

### 🌐 Caddy-ready deployment
- `docs/Caddyfile` example with `forward_auth` to Authentik outpost
- `docker