### PR TITLE
Support multiple IP and MAC addresses per device

### DIFF
--- a/backend/app/routes/map_routes.py
+++ b/backend/app/routes/map_routes.py
@@ -22,7 +22,7 @@ def get_network_for_ip(ip_addr):
     """Determine which network an IP address belongs to based on subnet matching."""
     if not ip_addr:
         return None
-    
+
     try:
         ip = ip_address(ip_addr)
         # Check all networks to see if this IP is in their subnet
@@ -36,8 +36,26 @@ def get_network_for_ip(ip_addr):
                     continue
     except (AddressValueError, ValueError):
         pass
-    
+
     return None
+
+
+def get_networks_for_ips(ip_field):
+    """Return all matching networks for a comma-separated IP address field."""
+    if not ip_field:
+        return []
+
+    seen_ids = set()
+    results = []
+    for single_ip in ip_field.split(","):
+        single_ip = single_ip.strip()
+        if not single_ip:
+            continue
+        network = get_network_for_ip(single_ip)
+        if network and network.id not in seen_ids:
+            seen_ids.add(network.id)
+            results.append(network)
+    return results
 
 
 @bp.route("/graph", methods=["GET"])
@@ -81,14 +99,20 @@ def get_graph():
                     node_data["icon"] = item.icon
                     node_data["label"] = item.icon  # Only show the icon
             
-            # Automatically determine network membership based on IP address
+            # Automatically determine network membership based on IP addresses
             if hasattr(item, "ip_address") and item.ip_address:
-                network = get_network_for_ip(item.ip_address)
-                if network:
-                    node_data["networkId"] = network.id
-                    node_data["networkName"] = network.name
-                    # Use network color or default if not set
-                    node_data["networkColor"] = network.color or "#E74C3C"
+                matched_networks = get_networks_for_ips(item.ip_address)
+                if matched_networks:
+                    # Primary network (first match) for border color
+                    node_data["networkId"] = matched_networks[0].id
+                    node_data["networkName"] = matched_networks[0].name
+                    node_data["networkColor"] = matched_networks[0].color or "#E74C3C"
+                    # All networks for the info panel
+                    if len(matched_networks) > 1:
+                        node_data["networks"] = [
+                            {"id": n.id, "name": n.name, "color": n.color or "#E74C3C"}
+                            for n in matched_networks
+                        ]
             
             nodes.append({"data": node_data})
 
@@ -153,11 +177,16 @@ def get_graph():
         
         # Add network membership if share has an IP
         if share.ip:
-            network = get_network_for_ip(share.ip)
-            if network:
-                node_data["networkId"] = network.id
-                node_data["networkName"] = network.name
-                node_data["networkColor"] = network.color or "#E74C3C"
+            matched_networks = get_networks_for_ips(share.ip)
+            if matched_networks:
+                node_data["networkId"] = matched_networks[0].id
+                node_data["networkName"] = matched_networks[0].name
+                node_data["networkColor"] = matched_networks[0].color or "#E74C3C"
+                if len(matched_networks) > 1:
+                    node_data["networks"] = [
+                        {"id": n.id, "name": n.name, "color": n.color or "#E74C3C"}
+                        for n in matched_networks
+                    ]
         
         nodes.append({"data": node_data})
         

--- a/frontend/src/components/inventory/AppForm.svelte
+++ b/frontend/src/components/inventory/AppForm.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { get } from "../../lib/api.js";
   import IconPicker from "./IconPicker.svelte";
+  import MultiInput from "./MultiInput.svelte";
 
   export let item = {};
 
@@ -10,6 +11,13 @@
   let parentType = item.vm_id ? "vm" : item.hardware_id ? "hardware" : "none";
   let previousHardwareId = item.hardware_id;
   let previousVmId = item.vm_id;
+
+  let ipAddresses = item.ip_address ? item.ip_address.split(",").map(s => s.trim()).filter(Boolean) : [];
+
+  function handleIpChange(e) {
+    ipAddresses = e.detail;
+    item.ip_address = ipAddresses.filter(Boolean).join(", ") || null;
+  }
 
   onMount(async () => {
     try {
@@ -34,15 +42,18 @@
     }
   }
 
-  // Auto-populate hostname and IP from parent only when creating a new app
+  // Auto-populate hostname and first IP from parent only when creating a new app
   $: if (!item.id && item.hardware_id && hardwareOptions.length > 0 && item.hardware_id !== previousHardwareId) {
     const hardware = hardwareOptions.find(h => h.id === item.hardware_id);
     if (hardware) {
       if (hardware.hostname && !item.hostname) {
         item.hostname = hardware.hostname;
       }
-      if (hardware.ip_address && !item.ip_address) {
-        item.ip_address = hardware.ip_address;
+      if (hardware.ip_address && ipAddresses.length === 0) {
+        // Take the first IP from the parent
+        const firstIp = hardware.ip_address.split(",")[0].trim();
+        ipAddresses = [firstIp];
+        item.ip_address = firstIp;
       }
     }
     previousHardwareId = item.hardware_id;
@@ -54,8 +65,10 @@
       if (vm.hostname && !item.hostname) {
         item.hostname = vm.hostname;
       }
-      if (vm.ip_address && !item.ip_address) {
-        item.ip_address = vm.ip_address;
+      if (vm.ip_address && ipAddresses.length === 0) {
+        const firstIp = vm.ip_address.split(",")[0].trim();
+        ipAddresses = [firstIp];
+        item.ip_address = firstIp;
       }
     }
     previousVmId = item.vm_id;
@@ -99,7 +112,12 @@
 <label>Description<input type="text" bind:value={item.description} /></label>
 <div class="grid">
   <label>Hostname<input type="text" bind:value={item.hostname} placeholder="Defaults to parent hostname" /></label>
-  <label>IP Address<input type="text" bind:value={item.ip_address} placeholder="Defaults to parent IP" /></label>
+  <MultiInput
+    label="IP Addresses"
+    placeholder="Defaults to parent IP"
+    values={ipAddresses}
+    on:change={handleIpChange}
+  />
 </div>
 <div class="grid">
   <label>External Hostname<input type="text" bind:value={item.external_hostname} /></label>

--- a/frontend/src/components/inventory/EntityDetail.svelte
+++ b/frontend/src/components/inventory/EntityDetail.svelte
@@ -43,11 +43,11 @@
           // Fetch grandparent (hardware or vm) details for default IP/hostname
           if (item.hardware_id) {
             const hwRes = await get(`/hardware/${item.hardware_id}`);
-            parentIp = hwRes.data.ip_address || '';
+            parentIp = (hwRes.data.ip_address || '').split(',')[0].trim();
             parentHostname = hwRes.data.hostname || '';
           } else if (item.vm_id) {
             const vmRes = await get(`/vms/${item.vm_id}`);
-            parentIp = vmRes.data.ip_address || '';
+            parentIp = (vmRes.data.ip_address || '').split(',')[0].trim();
             parentHostname = vmRes.data.hostname || '';
           }
         }

--- a/frontend/src/components/inventory/HardwareForm.svelte
+++ b/frontend/src/components/inventory/HardwareForm.svelte
@@ -1,7 +1,22 @@
 <script>
   import IconPicker from "./IconPicker.svelte";
+  import MultiInput from "./MultiInput.svelte";
 
   export let item = {};
+
+  // Parse comma-separated strings into arrays for editing
+  let ipAddresses = item.ip_address ? item.ip_address.split(",").map(s => s.trim()).filter(Boolean) : [];
+  let macAddresses = item.mac_address ? item.mac_address.split(",").map(s => s.trim()).filter(Boolean) : [];
+
+  function handleIpChange(e) {
+    ipAddresses = e.detail;
+    item.ip_address = ipAddresses.filter(Boolean).join(", ") || null;
+  }
+
+  function handleMacChange(e) {
+    macAddresses = e.detail;
+    item.mac_address = macAddresses.filter(Boolean).join(", ") || null;
+  }
 </script>
 
 <div class="grid">
@@ -9,8 +24,18 @@
   <label>Hostname<input type="text" bind:value={item.hostname} /></label>
 </div>
 <div class="grid">
-  <label>IP Address<input type="text" bind:value={item.ip_address} /></label>
-  <label>MAC Address<input type="text" bind:value={item.mac_address} placeholder="00:00:00:00:00:00" /></label>
+  <MultiInput
+    label="IP Addresses"
+    placeholder="e.g. 192.168.1.10"
+    values={ipAddresses}
+    on:change={handleIpChange}
+  />
+  <MultiInput
+    label="MAC Addresses"
+    placeholder="00:00:00:00:00:00"
+    values={macAddresses}
+    on:change={handleMacChange}
+  />
 </div>
 <div class="grid">
   <label>OS<input type="text" bind:value={item.os} /></label>

--- a/frontend/src/components/inventory/MiscForm.svelte
+++ b/frontend/src/components/inventory/MiscForm.svelte
@@ -1,7 +1,15 @@
 <script>
   import IconPicker from "./IconPicker.svelte";
+  import MultiInput from "./MultiInput.svelte";
 
   export let item = {};
+
+  let ipAddresses = item.ip_address ? item.ip_address.split(",").map(s => s.trim()).filter(Boolean) : [];
+
+  function handleIpChange(e) {
+    ipAddresses = e.detail;
+    item.ip_address = ipAddresses.filter(Boolean).join(", ") || null;
+  }
 </script>
 
 <div class="grid">
@@ -10,7 +18,12 @@
 </div>
 <div class="grid">
   <label>Hostname<input type="text" bind:value={item.hostname} /></label>
-  <label>IP Address<input type="text" bind:value={item.ip_address} /></label>
+  <MultiInput
+    label="IP Addresses"
+    placeholder="e.g. 192.168.1.10"
+    values={ipAddresses}
+    on:change={handleIpChange}
+  />
 </div>
 <label>Description<textarea bind:value={item.description} rows="2"></textarea></label>
 <IconPicker bind:value={item.icon} />

--- a/frontend/src/components/inventory/MultiInput.svelte
+++ b/frontend/src/components/inventory/MultiInput.svelte
@@ -1,0 +1,119 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  export let values = [];
+  export let placeholder = "";
+  export let label = "";
+
+  const dispatch = createEventDispatcher();
+
+  function addValue() {
+    values = [...values, ""];
+    dispatch("change", values);
+  }
+
+  function removeValue(index) {
+    values = values.filter((_, i) => i !== index);
+    dispatch("change", values);
+  }
+
+  function updateValue(index, val) {
+    values[index] = val;
+    values = values;
+    dispatch("change", values);
+  }
+</script>
+
+<div class="multi-input">
+  <div class="multi-input-header">
+    <span class="multi-input-label">{label}</span>
+    <button type="button" class="add-btn" on:click={addValue}>+ Add</button>
+  </div>
+  {#if values.length === 0}
+    <button type="button" class="add-first-btn" on:click={addValue}>+ Add {label.toLowerCase()}</button>
+  {:else}
+    {#each values as value, index}
+      <div class="multi-input-row">
+        <input
+          type="text"
+          {placeholder}
+          value={value}
+          on:input={(e) => updateValue(index, e.target.value)}
+        />
+        <button type="button" class="remove-btn" on:click={() => removeValue(index)}>&times;</button>
+      </div>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .multi-input {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .multi-input-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .multi-input-label {
+    font-size: 0.9rem;
+    font-weight: 500;
+  }
+  .add-btn {
+    padding: 0.15rem 0.5rem;
+    font-size: 0.75rem;
+    margin: 0;
+    background: transparent;
+    border: 1px solid #666;
+    color: #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .add-btn:hover {
+    border-color: #999;
+    color: #fff;
+  }
+  .add-first-btn {
+    padding: 0.4rem 0.75rem;
+    font-size: 0.8rem;
+    margin: 0;
+    background: transparent;
+    border: 1px dashed #555;
+    color: #999;
+    border-radius: 4px;
+    cursor: pointer;
+    width: 100%;
+    text-align: center;
+  }
+  .add-first-btn:hover {
+    border-color: #888;
+    color: #ccc;
+  }
+  .multi-input-row {
+    display: flex;
+    gap: 0.35rem;
+    align-items: center;
+  }
+  .multi-input-row input {
+    flex: 1;
+    margin: 0;
+  }
+  .remove-btn {
+    padding: 0.25rem 0.5rem;
+    margin: 0;
+    background: transparent;
+    border: 1px solid rgba(220, 53, 69, 0.3);
+    color: rgba(220, 53, 69, 0.8);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+  .remove-btn:hover {
+    background: rgba(220, 53, 69, 0.15);
+    border-color: rgba(220, 53, 69, 0.5);
+  }
+</style>

--- a/frontend/src/components/inventory/VmForm.svelte
+++ b/frontend/src/components/inventory/VmForm.svelte
@@ -2,10 +2,24 @@
   import { onMount } from "svelte";
   import { get } from "../../lib/api.js";
   import IconPicker from "./IconPicker.svelte";
+  import MultiInput from "./MultiInput.svelte";
 
   export let item = {};
 
   let hardwareOptions = [];
+
+  let ipAddresses = item.ip_address ? item.ip_address.split(",").map(s => s.trim()).filter(Boolean) : [];
+  let macAddresses = item.mac_address ? item.mac_address.split(",").map(s => s.trim()).filter(Boolean) : [];
+
+  function handleIpChange(e) {
+    ipAddresses = e.detail;
+    item.ip_address = ipAddresses.filter(Boolean).join(", ") || null;
+  }
+
+  function handleMacChange(e) {
+    macAddresses = e.detail;
+    item.mac_address = macAddresses.filter(Boolean).join(", ") || null;
+  }
 
   onMount(async () => {
     try {
@@ -31,11 +45,21 @@
 </div>
 <div class="grid">
   <label>Hostname<input type="text" bind:value={item.hostname} /></label>
-  <label>IP Address<input type="text" bind:value={item.ip_address} /></label>
+  <label>OS<input type="text" bind:value={item.os} /></label>
 </div>
 <div class="grid">
-  <label>MAC Address<input type="text" bind:value={item.mac_address} placeholder="00:00:00:00:00:00" /></label>
-  <label>OS<input type="text" bind:value={item.os} /></label>
+  <MultiInput
+    label="IP Addresses"
+    placeholder="e.g. 192.168.1.10"
+    values={ipAddresses}
+    on:change={handleIpChange}
+  />
+  <MultiInput
+    label="MAC Addresses"
+    placeholder="00:00:00:00:00:00"
+    values={macAddresses}
+    on:change={handleMacChange}
+  />
 </div>
 <div class="grid">
   <label>CPU Cores<input type="number" bind:value={item.cpu_cores} /></label>

--- a/frontend/src/components/map/NetworkMap.svelte
+++ b/frontend/src/components/map/NetworkMap.svelte
@@ -402,16 +402,40 @@
           </div>
         {/if}
         {#if selectedNodeDetails.ip_address || selectedNodeDetails.ip}
-          <div class="info-item">
-            <span class="info-label">IP Address:</span>
-            <span class="info-value">{selectedNodeDetails.ip_address || selectedNodeDetails.ip}</span>
-          </div>
+          {@const ips = (selectedNodeDetails.ip_address || selectedNodeDetails.ip || "").split(",").map(s => s.trim()).filter(Boolean)}
+          {#if ips.length <= 1}
+            <div class="info-item">
+              <span class="info-label">IP Address:</span>
+              <span class="info-value">{ips[0] || ""}</span>
+            </div>
+          {:else}
+            <div class="info-item multi-value">
+              <span class="info-label">IP Addresses:</span>
+              <span class="info-value">
+                {#each ips as ip}
+                  <span class="value-chip">{ip}</span>
+                {/each}
+              </span>
+            </div>
+          {/if}
         {/if}
         {#if selectedNodeDetails.mac_address}
-          <div class="info-item">
-            <span class="info-label">MAC Address:</span>
-            <span class="info-value">{selectedNodeDetails.mac_address}</span>
-          </div>
+          {@const macs = selectedNodeDetails.mac_address.split(",").map(s => s.trim()).filter(Boolean)}
+          {#if macs.length <= 1}
+            <div class="info-item">
+              <span class="info-label">MAC Address:</span>
+              <span class="info-value">{macs[0] || ""}</span>
+            </div>
+          {:else}
+            <div class="info-item multi-value">
+              <span class="info-label">MAC Addresses:</span>
+              <span class="info-value">
+                {#each macs as mac}
+                  <span class="value-chip">{mac}</span>
+                {/each}
+              </span>
+            </div>
+          {/if}
         {/if}
         {#if selectedNodeDetails.os}
           <div class="info-item">
@@ -444,11 +468,12 @@
           </div>
         {/if}
         {#if selectedNode.type === 'apps' && selectedNodeDetails.port && (selectedNodeDetails.hostname || selectedNodeDetails.ip_address)}
+          {@const linkHost = selectedNodeDetails.hostname || (selectedNodeDetails.ip_address || "").split(",")[0].trim()}
           <div class="info-item">
             <span class="info-label">Link:</span>
             <span class="info-value">
-              <a href="{selectedNodeDetails.https ? 'https' : 'http'}://{selectedNodeDetails.hostname || selectedNodeDetails.ip_address}:{selectedNodeDetails.port}" target="_blank" rel="noopener noreferrer">
-                {selectedNodeDetails.hostname || selectedNodeDetails.ip_address}:{selectedNodeDetails.port}
+              <a href="{selectedNodeDetails.https ? 'https' : 'http'}://{linkHost}:{selectedNodeDetails.port}" target="_blank" rel="noopener noreferrer">
+                {linkHost}:{selectedNodeDetails.port}
               </a>
             </span>
           </div>
@@ -502,7 +527,19 @@
           </div>
         {/if}
       {/if}
-      {#if selectedNode.networkName}
+      {#if selectedNode.networks && selectedNode.networks.length > 1}
+        <div class="info-item multi-value">
+          <span class="info-label">Networks:</span>
+          <span class="info-value">
+            {#each selectedNode.networks as net}
+              <span class="network-chip">
+                <span class="network-indicator" style="background-color: {net.color}"></span>
+                {net.name}
+              </span>
+            {/each}
+          </span>
+        </div>
+      {:else if selectedNode.networkName}
         <div class="info-item">
           <span class="info-label">Network:</span>
           <span class="info-value">
@@ -820,6 +857,32 @@
   }
   .legend-item svg {
     flex-shrink: 0;
+  }
+  .info-item.multi-value {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.3rem;
+  }
+  .info-item.multi-value .info-value {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+  }
+  .value-chip {
+    background: rgba(255, 255, 255, 0.1);
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    font-size: 0.8rem;
+    font-family: monospace;
+  }
+  .network-chip {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: rgba(255, 255, 255, 0.08);
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    font-size: 0.8rem;
   }
   .node-tooltip {
     position: absolute;

--- a/frontend/src/components/map/TreeView.svelte
+++ b/frontend/src/components/map/TreeView.svelte
@@ -165,15 +165,17 @@
               </div>
             {/if}
             {#if selectedNodeDetails.ip_address || selectedNodeDetails.ip}
+              {@const ips = (selectedNodeDetails.ip_address || selectedNodeDetails.ip || "").split(",").map(s => s.trim()).filter(Boolean)}
               <div class="info-item">
-                <span class="info-label">IP Address:</span>
-                <span class="info-value">{selectedNodeDetails.ip_address || selectedNodeDetails.ip}</span>
+                <span class="info-label">{ips.length > 1 ? "IP Addresses:" : "IP Address:"}</span>
+                <span class="info-value">{ips.join(", ")}</span>
               </div>
             {/if}
             {#if selectedNodeDetails.mac_address}
+              {@const macs = selectedNodeDetails.mac_address.split(",").map(s => s.trim()).filter(Boolean)}
               <div class="info-item">
-                <span class="info-label">MAC Address:</span>
-                <span class="info-value">{selectedNodeDetails.mac_address}</span>
+                <span class="info-label">{macs.length > 1 ? "MAC Addresses:" : "MAC Address:"}</span>
+                <span class="info-value">{macs.join(", ")}</span>
               </div>
             {/if}
             {#if selectedNodeDetails.os}
@@ -207,11 +209,12 @@
               </div>
             {/if}
             {#if selectedNode.type === 'apps' && selectedNodeDetails.port && (selectedNodeDetails.hostname || selectedNodeDetails.ip_address)}
+              {@const linkHost = selectedNodeDetails.hostname || (selectedNodeDetails.ip_address || "").split(",")[0].trim()}
               <div class="info-item">
                 <span class="info-label">Link:</span>
                 <span class="info-value">
-                  <a href="{selectedNodeDetails.https ? 'https' : 'http'}://{selectedNodeDetails.hostname || selectedNodeDetails.ip_address}:{selectedNodeDetails.port}" target="_blank" rel="noopener noreferrer">
-                    {selectedNodeDetails.hostname || selectedNodeDetails.ip_address}:{selectedNodeDetails.port}
+                  <a href="{selectedNodeDetails.https ? 'https' : 'http'}://{linkHost}:{selectedNodeDetails.port}" target="_blank" rel="noopener noreferrer">
+                    {linkHost}:{selectedNodeDetails.port}
                   </a>
                 </span>
               </div>


### PR DESCRIPTION
## Summary

- Devices (hardware, VMs, apps, misc) can now have **multiple IP and MAC addresses**, stored as comma-separated values in the existing text columns (no schema migration needed)
- New reusable `MultiInput` component provides dynamic add/remove fields in all entity forms
- The network map now matches all IPs against network subnets, so devices spanning multiple VLANs/networks show all memberships in the info panel
- Backward compatible: existing single-IP entries continue to work as-is

## Test plan

- [ ] Create a hardware item with multiple IP addresses and verify they save/load correctly
- [ ] Edit an existing hardware item to add a second IP and confirm persistence
- [ ] Verify the network map assigns a device to multiple networks when its IPs span different subnets
- [ ] Click a multi-IP node in the map and confirm the info panel shows all IPs and all networks
- [ ] Create an app under a multi-IP hardware parent and verify the first IP auto-populates
- [ ] Test export/import with multi-IP devices
- [ ] Verify the tree view displays multiple IPs correctly

Closes #10