### PR TITLE
Add hardware type field for categorizing devices

### DIFF
--- a/backend/app/models/hardware.py
+++ b/backend/app/models/hardware.py
@@ -6,6 +6,7 @@ class Hardware(BaseMixin, db.Model):
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.Text, nullable=False)
+    hardware_type = db.Column(db.Text)
     hostname = db.Column(db.Text)
     ip_address = db.Column(db.Text)
     mac_address = db.Column(db.Text)

--- a/backend/migrations/versions/009_add_hardware_type.py
+++ b/backend/migrations/versions/009_add_hardware_type.py
@@ -1,0 +1,25 @@
+"""add hardware_type to hardware
+
+Revision ID: 009_add_hardware_type
+Revises: 008_add_mac_address
+Create Date: 2026-03-22
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from utils.migration_helpers import add_column_if_not_exists
+
+
+# revision identifiers, used by Alembic.
+revision = '009_add_hardware_type'
+down_revision = '008_add_mac_address'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    add_column_if_not_exists('hardware', sa.Column('hardware_type', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('hardware', 'hardware_type')

--- a/frontend/src/components/inventory/EntityList.svelte
+++ b/frontend/src/components/inventory/EntityList.svelte
@@ -30,7 +30,7 @@
   };
 
   const COLUMNS = {
-    hardware: ["name", "hostname", "ip_address", "os", "cpu", "ram_gb"],
+    hardware: ["name", "hardware_type", "hostname", "ip_address", "os", "cpu", "ram_gb"],
     vms: ["name", "hostname", "ip_address", "os", "cpu_cores", "ram_gb"],
     apps: ["name", "hostname", "ip_address", "external_hostname", "port"],
     storage: ["name", "storage_type", "raid_type", "raw_space_tb", "usable_space_tb"],
@@ -39,6 +39,7 @@
   };
 
   const LABELS = {
+    hardware_type: "Type",
     ip_address: "IP Address",
     ram_gb: "RAM (GB)",
     cpu_cores: "CPU Cores",
@@ -196,7 +197,7 @@
           {#each sorted as item (item.id)}
             <tr on:click={() => push(`/inventory/${type}/${item.id}`)} class="clickable">
               {#each columns as col}
-                <td>{item[col] ?? ""}</td>
+                <td>{col === 'hardware_type' && item[col] ? item[col].replace(/_/g, ' ') : item[col] ?? ""}</td>
               {/each}
               <td>
                 <div class="button-group">

--- a/frontend/src/components/inventory/HardwareForm.svelte
+++ b/frontend/src/components/inventory/HardwareForm.svelte
@@ -6,6 +6,22 @@
 
 <div class="grid">
   <label>Name *<input type="text" bind:value={item.name} required /></label>
+  <label>
+    Type
+    <select bind:value={item.hardware_type}>
+      <option value="">Select type...</option>
+      <option value="server">Server</option>
+      <option value="switch">Switch</option>
+      <option value="router">Router</option>
+      <option value="firewall">Firewall</option>
+      <option value="access_point">Access Point</option>
+      <option value="nas">NAS</option>
+      <option value="ups">UPS</option>
+      <option value="other">Other</option>
+    </select>
+  </label>
+</div>
+<div class="grid">
   <label>Hostname<input type="text" bind:value={item.hostname} /></label>
 </div>
 <div class="grid">

--- a/frontend/src/components/map/NetworkMap.svelte
+++ b/frontend/src/components/map/NetworkMap.svelte
@@ -395,6 +395,12 @@
           <span class="info-label">Loading...</span>
         </div>
       {:else if selectedNodeDetails}
+        {#if selectedNodeDetails.hardware_type}
+          <div class="info-item">
+            <span class="info-label">Hardware Type:</span>
+            <span class="info-value">{selectedNodeDetails.hardware_type.replace(/_/g, ' ')}</span>
+          </div>
+        {/if}
         {#if selectedNodeDetails.hostname}
           <div class="info-item">
             <span class="info-label">Hostname:</span>

--- a/frontend/src/components/map/TreeView.svelte
+++ b/frontend/src/components/map/TreeView.svelte
@@ -158,6 +158,12 @@
               <span class="info-label">Loading...</span>
             </div>
           {:else if selectedNodeDetails}
+            {#if selectedNodeDetails.hardware_type}
+              <div class="info-item">
+                <span class="info-label">Hardware Type:</span>
+                <span class="info-value">{selectedNodeDetails.hardware_type.replace(/_/g, ' ')}</span>
+              </div>
+            {/if}
             {#if selectedNodeDetails.hostname}
               <div class="info-item">
                 <span class="info-label">Hostname:</span>


### PR DESCRIPTION
## Summary

- Adds a `hardware_type` dropdown to hardware entities with predefined options: **Server, Switch, Router, Firewall, Access Point, NAS, UPS, Other**
- New Alembic migration (`009_add_hardware_type`) adds the column to the database
- Hardware type is displayed in the inventory list table and in map info panels (both graph and tree view)
- Backward compatible: existing hardware entries will have an empty type which can be set at any time

> **Note:** The original issue also mentions port tracking with device linking — that would be a larger follow-up feature building on top of this categorization.

## Test plan

- [ ] Create new hardware with a type selected and verify it saves
- [ ] Edit existing hardware to add a type and confirm persistence
- [ ] Verify the hardware list table shows the Type column with human-readable labels
- [ ] Click a hardware node in the network map and verify Hardware Type shows in the info panel
- [ ] Check the tree view info panel also displays hardware type
- [ ] Run `alembic upgrade head` and verify the migration applies cleanly
- [ ] Export/import and verify hardware_type is preserved

Closes #26