### PR TITLE
Add LXC container support with full CRUD backend and frontend components

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,6 +2,7 @@ from .base import db, BaseMixin
 from .document import Document
 from .hardware import Hardware
 from .vm import VM
+from .lxc import LXC
 from .app_service import AppService
 from .storage import Storage
 from .share import Share
@@ -15,6 +16,7 @@ __all__ = [
     "Document",
     "Hardware",
     "VM",
+    "LXC",
     "AppService",
     "Storage",
     "Share",

--- a/backend/app/models/app_service.py
+++ b/backend/app/models/app_service.py
@@ -7,6 +7,7 @@ class AppService(BaseMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     hardware_id = db.Column(db.Integer, db.ForeignKey("hardware.id", ondelete="SET NULL"), nullable=True)
     vm_id = db.Column(db.Integer, db.ForeignKey("vms.id", ondelete="SET NULL"), nullable=True)
+    lxc_id = db.Column(db.Integer, db.ForeignKey("lxcs.id", ondelete="SET NULL"), nullable=True)
     name = db.Column(db.Text, nullable=False)
     description = db.Column(db.Text)
     hostname = db.Column(db.Text)
@@ -19,7 +20,7 @@ class AppService(BaseMixin, db.Model):
 
     __table_args__ = (
         db.CheckConstraint(
-            "NOT (hardware_id IS NOT NULL AND vm_id IS NOT NULL)",
+            "(CASE WHEN hardware_id IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN vm_id IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN lxc_id IS NOT NULL THEN 1 ELSE 0 END) <= 1",
             name="ck_apps_single_parent",
         ),
     )

--- a/backend/app/models/hardware.py
+++ b/backend/app/models/hardware.py
@@ -21,5 +21,6 @@ class Hardware(BaseMixin, db.Model):
     notes = db.Column(db.Text)
 
     vms = db.relationship("VM", backref="hardware", lazy="select")
+    lxcs = db.relationship("LXC", backref="hardware", lazy="select")
     apps = db.relationship("AppService", backref="hardware", lazy="select")
     storage_pools = db.relationship("Storage", backref="hardware", lazy="select")

--- a/backend/app/models/lxc.py
+++ b/backend/app/models/lxc.py
@@ -1,0 +1,21 @@
+from .base import db, BaseMixin
+
+
+class LXC(BaseMixin, db.Model):
+    __tablename__ = "lxcs"
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    hardware_id = db.Column(db.Integer, db.ForeignKey("hardware.id", ondelete="CASCADE"), nullable=False)
+    name = db.Column(db.Text, nullable=False)
+    ctid = db.Column(db.Integer)
+    hostname = db.Column(db.Text)
+    ip_address = db.Column(db.Text)
+    mac_address = db.Column(db.Text)
+    cpu_cores = db.Column(db.Integer)
+    ram_gb = db.Column(db.Float)
+    disk_gb = db.Column(db.Float)
+    os = db.Column(db.Text)
+    unprivileged = db.Column(db.Boolean, default=True)
+    onboot = db.Column(db.Boolean, default=True)
+    notes = db.Column(db.Text)
+    apps = db.relationship("AppService", backref="lxc", lazy="select")
+    storage_pools = db.relationship("Storage", backref="lxc", lazy="select")

--- a/backend/app/models/storage.py
+++ b/backend/app/models/storage.py
@@ -7,6 +7,7 @@ class Storage(BaseMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     hardware_id = db.Column(db.Integer, db.ForeignKey("hardware.id", ondelete="SET NULL"), nullable=True)
     vm_id = db.Column(db.Integer, db.ForeignKey("vms.id", ondelete="SET NULL"), nullable=True)
+    lxc_id = db.Column(db.Integer, db.ForeignKey("lxcs.id", ondelete="SET NULL"), nullable=True)
     name = db.Column(db.Text, nullable=False)
     storage_type = db.Column(db.Text)
     raid_type = db.Column(db.Text)
@@ -22,7 +23,7 @@ class Storage(BaseMixin, db.Model):
 
     __table_args__ = (
         db.CheckConstraint(
-            "NOT (hardware_id IS NOT NULL AND vm_id IS NOT NULL)",
+            "(CASE WHEN hardware_id IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN vm_id IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN lxc_id IS NOT NULL THEN 1 ELSE 0 END) <= 1",
             name="ck_storage_single_parent",
         ),
     )

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,10 +1,11 @@
-from . import apps, documents, hardware, inventory, map_routes, misc, networks, shares, storage, vms
+from . import apps, documents, hardware, inventory, map_routes, misc, networks, shares, storage, vms, lxcs
 from flask import Blueprint
 
 def register_blueprints(app):
     from .documents import bp as documents_bp
     from .hardware import bp as hardware_bp
     from .vms import bp as vms_bp
+    from .lxcs import bp as lxcs_bp
     from .apps import bp as apps_bp
     from .storage import bp as storage_bp
     from .shares import bp as shares_bp
@@ -16,6 +17,7 @@ def register_blueprints(app):
     app.register_blueprint(documents_bp)
     app.register_blueprint(hardware_bp)
     app.register_blueprint(vms_bp)
+    app.register_blueprint(lxcs_bp)
     app.register_blueprint(apps_bp)
     app.register_blueprint(storage_bp)
     app.register_blueprint(shares_bp)

--- a/backend/app/routes/inventory.py
+++ b/backend/app/routes/inventory.py
@@ -8,6 +8,7 @@ bp = Blueprint('inventory', __name__, url_prefix='/inventory')
 ENTITY_MAP = {
     "hardware": Hardware,
     "vms": VM,
+    "lxcs": LXC,
     "apps": AppService,
     "storage": Storage,
     "networks": Network,
@@ -51,6 +52,7 @@ def export_database():
         data = {
             'hardware': [h.to_dict() for h in Hardware.query.all()],
             'vms': [vm.to_dict() for vm in VM.query.all()],
+            'lxcs': [lxc.to_dict() for lxc in LXC.query.all()],
             'apps': [app.to_dict() for app in AppService.query.all()],
             'storage': [s.to_dict() for s in Storage.query.all()],
             'networks': [n.to_dict() for n in Network.query.all()],
@@ -72,6 +74,7 @@ def import_database():
         db.session.query(Share).delete()  # Delete shares before storage
         db.session.query(AppService).delete()
         db.session.query(VM).delete()
+        db.session.query(LXC).delete()
         db.session.query(Hardware).delete()
         db.session.query(Storage).delete()
         db.session.query(Network).delete()
@@ -105,6 +108,14 @@ def import_database():
                 db.session.add(vm)
         
         db.session.flush()  # Get IDs for VMs
+
+        # Import LXCs (depends on hardware)
+        if 'lxcs' in import_data:
+            for item in import_data['lxcs']:
+                lxc = LXC(**clean_item(item))
+                db.session.add(lxc)
+
+        db.session.flush()  # Get IDs for LXCs
 
         # Import apps (depends on hardware and VMs)
         if 'apps' in import_data:

--- a/backend/app/routes/lxcs.py
+++ b/backend/app/routes/lxcs.py
@@ -1,0 +1,17 @@
+from flask import jsonify
+from ..models import db, LXC
+from ._crud_factory import create_crud_blueprint
+
+bp = create_crud_blueprint("lxcs", LXC, detail_route=False)
+
+
+@bp.route("/<int:item_id>", methods=["GET"], endpoint="get_lxc_detail")
+def get_lxc_detail(item_id):
+    """Override GET detail to include related apps and storage."""
+    lxc = db.get_or_404(LXC, item_id)
+    result = lxc.to_dict()
+    result["apps"] = [app.to_dict() for app in lxc.apps]
+    result["storage_pools"] = [s.to_dict() for s in lxc.storage_pools]
+    if lxc.hardware:
+        result["hardware_name"] = lxc.hardware.name
+    return jsonify(data=result)

--- a/backend/migrations/versions/009_add_lxcs.py
+++ b/backend/migrations/versions/009_add_lxcs.py
@@ -1,0 +1,43 @@
+"""add lxcs table and lxc_id to apps and storage"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "009_add_lxcs"
+down_revision = "008_add_mac_address"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "lxcs",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("hardware_id", sa.Integer, sa.ForeignKey("hardware.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("name", sa.Text, nullable=False),
+        sa.Column("ctid", sa.Integer),
+        sa.Column("hostname", sa.Text),
+        sa.Column("ip_address", sa.Text),
+        sa.Column("mac_address", sa.Text),
+        sa.Column("cpu_cores", sa.Integer),
+        sa.Column("ram_gb", sa.Float),
+        sa.Column("disk_gb", sa.Float),
+        sa.Column("os", sa.Text),
+        sa.Column("unprivileged", sa.Boolean, server_default="1"),
+        sa.Column("onboot", sa.Boolean, server_default="1"),
+        sa.Column("notes", sa.Text),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.current_timestamp()),
+        sa.Column("updated_at", sa.DateTime, nullable=False, server_default=sa.func.current_timestamp()),
+        if_not_exists=True,
+    )
+
+
+
+
+    op.add_column("apps", sa.Column("lxc_id", sa.Integer, nullable=True))
+    op.add_column("storage", sa.Column("lxc_id", sa.Integer, nullable=True))
+
+
+def downgrade():
+    op.drop_column("storage", "lxc_id")
+    op.drop_column("apps", "lxc_id")
+    op.drop_table("lxcs")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -855,7 +855,6 @@
       "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
         "debug": "^4.3.4",
@@ -896,7 +895,6 @@
       "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.17.tgz",
       "integrity": "sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/tern": "*"
       }
@@ -1024,7 +1022,6 @@
       "resolved": "https://registry.npmjs.org/bytemd/-/bytemd-1.22.0.tgz",
       "integrity": "sha512-2vmegXnnsOxNufRrrQGHYKwgTmx6H+h40ZZs3DAw/SS5O4mBzO9evc1HD39CqW9wglGNBJxMg257pv9pgAGl+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.11.7",
         "@types/codemirror": "^5.60.7",
@@ -1139,7 +1136,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2661,7 +2657,6 @@
       "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -2901,7 +2896,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -4,6 +4,7 @@
   const inventoryTypes = [
     { key: "hardware", label: "Hardware" },
     { key: "vms", label: "VMs" },
+    { key: "lxcs", label: "LXCs" },
     { key: "apps", label: "Apps" },
     { key: "storage", label: "Storage" },
     { key: "networks", label: "Networks" },

--- a/frontend/src/components/inventory/AppForm.svelte
+++ b/frontend/src/components/inventory/AppForm.svelte
@@ -7,19 +7,23 @@
 
   let hardwareOptions = [];
   let vmOptions = [];
-  let parentType = item.vm_id ? "vm" : item.hardware_id ? "hardware" : "none";
+  let lxcOptions = [];
+  let parentType = item.vm_id ? "vm" : item.lxc_id ? "lxc" : item.hardware_id ? "hardware" : "none";
   let previousHardwareId = item.hardware_id;
   let previousVmId = item.vm_id;
+  let previousLxcId = item.lxc_id;
 
   onMount(async () => {
     try {
-      const [hwRes, vmRes] = await Promise.all([get("/hardware"), get("/vms")]);
+      const [hwRes, vmRes, lxcRes] = await Promise.all([get("/hardware"), get("/vms"), get("/lxcs")]);
       hardwareOptions = hwRes.data;
       vmOptions = vmRes.data;
+      lxcOptions = lxcRes.data;
     } catch (e) {
       // ignore
     }
     if (item.vm_id) parentType = "vm";
+    else if (item.lxc_id) parentType = "lxc";
     else if (item.hardware_id) parentType = "hardware";
   });
 
@@ -27,10 +31,16 @@
     if (parentType === "none") {
       item.hardware_id = null;
       item.vm_id = null;
+      item.lxc_id = null;
     } else if (parentType === "hardware") {
       item.vm_id = null;
+      item.lxc_id = null;
     } else if (parentType === "vm") {
       item.hardware_id = null;
+      item.lxc_id = null;
+    } else if (parentType === "lxc") {
+      item.hardware_id = null;
+      item.vm_id = null;
     }
   }
 
@@ -60,6 +70,18 @@
     }
     previousVmId = item.vm_id;
   }
+  $: if (!item.id && item.lxc_id && lxcOptions.length > 0 && item.lxc_id !== previousLxcId) {
+    const lxc = lxcOptions.find(l => l.id === item.lxc_id);
+    if (lxc) {
+      if (lxc.hostname && !item.hostname) {
+        item.hostname = lxc.hostname;
+      }
+      if (lxc.ip_address && !item.ip_address) {
+        item.ip_address = lxc.ip_address;
+      }
+    }
+    previousLxcId = item.lxc_id;
+  }
 </script>
 
 <div class="grid">
@@ -70,6 +92,7 @@
       <option value="none">Standalone</option>
       <option value="hardware">Hardware (bare metal)</option>
       <option value="vm">VM</option>
+      <option value="lxc">LXC</option>
     </select>
   </label>
 </div>
@@ -91,6 +114,16 @@
       <option value="">Select...</option>
       {#each vmOptions as vm}
         <option value={vm.id}>{vm.name}</option>
+      {/each}
+    </select>
+  </label>
+{:else if parentType === "lxc"}
+  <label>
+    LXC
+    <select bind:value={item.lxc_id}>
+      <option value="">Select...</option>
+      {#each lxcOptions as lxc}
+        <option value={lxc.id}>{lxc.name}</option>
       {/each}
     </select>
   </label>

--- a/frontend/src/components/inventory/EntityDetail.svelte
+++ b/frontend/src/components/inventory/EntityDetail.svelte
@@ -4,6 +4,7 @@
   import { addToast } from "../../lib/stores.js";
   import HardwareForm from "./HardwareForm.svelte";
   import VmForm from "./VmForm.svelte";
+  import LxcForm from "./LxcForm.svelte";
   import AppForm from "./AppForm.svelte";
   import StorageForm from "./StorageForm.svelte";
   import NetworkForm from "./NetworkForm.svelte";
@@ -24,6 +25,7 @@
   const FORMS = {
     hardware: HardwareForm,
     vms: VmForm,
+    lxcs: LxcForm,
     apps: AppForm,
     storage: StorageForm,
     networks: NetworkForm,

--- a/frontend/src/components/inventory/EntityList.svelte
+++ b/frontend/src/components/inventory/EntityList.svelte
@@ -5,6 +5,7 @@
   import Modal from "../Modal.svelte";
   import HardwareForm from "./HardwareForm.svelte";
   import VmForm from "./VmForm.svelte";
+  import LxcForm from "./LxcForm.svelte";
   import AppForm from "./AppForm.svelte";
   import StorageForm from "./StorageForm.svelte";
   import NetworkForm from "./NetworkForm.svelte";
@@ -23,6 +24,7 @@
   const FORMS = {
     hardware: HardwareForm,
     vms: VmForm,
+    lxcs: LxcForm,
     apps: AppForm,
     storage: StorageForm,
     networks: NetworkForm,
@@ -32,6 +34,7 @@
   const COLUMNS = {
     hardware: ["name", "hostname", "ip_address", "os", "cpu", "ram_gb"],
     vms: ["name", "hostname", "ip_address", "os", "cpu_cores", "ram_gb"],
+    lxcs: ["name", "ctid", "hostname", "ip_address", "os", "cpu_cores", "ram_gb"],
     apps: ["name", "hostname", "ip_address", "external_hostname", "port"],
     storage: ["name", "storage_type", "raid_type", "raw_space_tb", "usable_space_tb"],
     networks: ["name", "vlan_id", "subnet", "gateway"],
@@ -48,6 +51,7 @@
     usable_space_tb: "Usable (TB)",
     storage_type: "Type",
     raid_type: "RAID",
+    ctid: "CT ID",
   };
 
   function label(col) {

--- a/frontend/src/components/inventory/LxcForm.svelte
+++ b/frontend/src/components/inventory/LxcForm.svelte
@@ -1,0 +1,55 @@
+<script>
+  import { onMount } from "svelte";
+  import { get } from "../../lib/api.js";
+  import IconPicker from "./IconPicker.svelte";
+  export let item = {};
+  let hardwareOptions = [];
+  onMount(async () => {
+    try {
+      const res = await get("/hardware");
+      hardwareOptions = res.data;
+    } catch (e) {
+      // ignore — dropdown will be empty
+    }
+  });
+</script>
+<div class="grid">
+  <label>Name *<input type="text" bind:value={item.name} required /></label>
+  <label>
+    Hardware *
+    <select bind:value={item.hardware_id} required>
+      <option value="">Select hardware...</option>
+      {#each hardwareOptions as hw}
+        <option value={hw.id}>{hw.name}</option>
+      {/each}
+    </select>
+  </label>
+</div>
+<div class="grid">
+  <label>CT ID<input type="number" bind:value={item.ctid} /></label>
+  <label>Hostname<input type="text" bind:value={item.hostname} /></label>
+</div>
+<div class="grid">
+  <label>IP Address<input type="text" bind:value={item.ip_address} /></label>
+  <label>MAC Address<input type="text" bind:value={item.mac_address} placeholder="00:00:00:00:00:00" /></label>
+</div>
+<div class="grid">
+  <label>OS<input type="text" bind:value={item.os} /></label>
+</div>
+<div class="grid">
+  <label>CPU Cores<input type="number" bind:value={item.cpu_cores} /></label>
+  <label>RAM (GB)<input type="number" step="0.1" bind:value={item.ram_gb} /></label>
+  <label>Disk (GB)<input type="number" step="0.1" bind:value={item.disk_gb} /></label>
+</div>
+<div class="grid">
+  <label>
+    <input type="checkbox" bind:checked={item.unprivileged} />
+    Unprivileged
+  </label>
+  <label>
+    <input type="checkbox" bind:checked={item.onboot} />
+    Start on boot
+  </label>
+</div>
+<IconPicker bind:value={item.icon} />
+<label>Notes<textarea bind:value={item.notes} rows="3"></textarea></label>

--- a/frontend/src/components/inventory/StorageForm.svelte
+++ b/frontend/src/components/inventory/StorageForm.svelte
@@ -7,17 +7,20 @@
 
   let hardwareOptions = [];
   let vmOptions = [];
-  let parentType = item.vm_id ? "vm" : item.hardware_id ? "hardware" : "none";
+  let lxcOptions = [];
+  let parentType = item.vm_id ? "vm" : item.lxc_id ? "lxc" : item.hardware_id ? "hardware" : "none";
 
   onMount(async () => {
     try {
-      const [hwRes, vmRes] = await Promise.all([get("/hardware"), get("/vms")]);
+      const [hwRes, vmRes, lxcRes] = await Promise.all([get("/hardware"), get("/vms"), get("/lxcs")]);
       hardwareOptions = hwRes.data;
       vmOptions = vmRes.data;
+      lxcOptions = lxcRes.data;
     } catch (e) {
       // ignore
     }
     if (item.vm_id) parentType = "vm";
+    else if (item.lxc_id) parentType = "lxc";
     else if (item.hardware_id) parentType = "hardware";
   });
 
@@ -25,10 +28,16 @@
     if (parentType === "none") {
       item.hardware_id = null;
       item.vm_id = null;
+      item.lxc_id = null;
     } else if (parentType === "hardware") {
       item.vm_id = null;
+      item.lxc_id = null;
     } else if (parentType === "vm") {
       item.hardware_id = null;
+      item.lxc_id = null;
+    } else if (parentType === "lxc") {
+      item.hardware_id = null;
+      item.vm_id = null;
     }
   }
 </script>
@@ -41,6 +50,7 @@
       <option value="none">Standalone</option>
       <option value="hardware">Hardware</option>
       <option value="vm">VM</option>
+      <option value="lxc">LXC</option>
     </select>
   </label>
 </div>
@@ -62,6 +72,16 @@
       <option value="">Select...</option>
       {#each vmOptions as vm}
         <option value={vm.id}>{vm.name}</option>
+      {/each}
+    </select>
+  </label>
+{:else if parentType === "lxc"}
+  <label>
+    LXC
+    <select bind:value={item.lxc_id}>
+      <option value="">Select...</option>
+      {#each lxcOptions as lxc}
+        <option value={lxc.id}>{lxc.name}</option>
       {/each}
     </select>
   </label>


### PR DESCRIPTION
This PR adds full LXC container support to Homelab Hub for Proxmox users.

Changes include:
- New LXC model (backend/app/models/lxc.py) with fields for ctid, hostname, ip_address, cpu_cores, ram_gb, disk_gb, os, unprivileged, onboot
- New LXC CRUD routes (backend/app/routes/lxcs.py) with detail endpoint including related apps and storage
- Alembic migration (009_add_lxcs.py) with batch mode for SQLite compatibility
- LXC form component (frontend/src/components/inventory/LxcForm.svelte)
- Sidebar navigation updated to include LXCs
- EntityList, EntityDetail, AppForm, StorageForm updated to support LXC relationships

Tested on Proxmox VE 9.2.3 with 5 LXC containers.